### PR TITLE
Add Tool specific input shaper parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ parameter to specify another tool.
     - Usefull when having sporadic toolchanges in a large print or many toolchanges in a small print.
   - Wait to reach temperature with tolerance. Set temperature +/- configurable tolerance.
 * Current Tool is saved and restored at powerdown. Default but optional.
+* Input shaper parameters for each tool.
 
 ## Installation Instructions
 ### Install with Moonraker Autoupdate Support
@@ -86,7 +87,7 @@ Then restart Klipper to pick up the extensions.
   * Mean Layer time Standby mode. - Save time at every layerchange and at toolchange set to mean time of last 3 layers *2 or at last layer *1.5 with a Maximum and a minimum time. Needs to be analyzed further.
   * Save the time it was in Standby last time and apply a fuzzfactor. Put tool in standby and heatup with presumption that next time will be aproximatley after the same time as last. +/- Fuzzfactor.
 * Implement Fan Scale. Can change fan scale for diffrent materials or tools from slicer at toolchange. Maybe max and min too?
-* Save pressure avance per tool to be restored on toolchange. Also between virtual tools. Check Slicer output first if this is needed or can be put in Filament. But then the filament in diffrent tools??
+* Save pressure avance per tool to be restored on toolchange. Also between virtual tools. Check Slicer output first if this is needed or can be put in Filament custom gcode.
 
 ## G-Code commands:
 * `TOOL_LOCK` - Lock command

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Then restart Klipper to pick up the extensions.
 ## G-Code commands:
 * `TOOL_LOCK` - Lock command
 * `TOOL_UNLOCK` - Unlock command
+* `Tn` - T0, T1, T2, etc... A select command is created for each tool.
 * `T_1` - Dropoff the current tool without picking up another tool
 * `SET_AND_SAVE_FAN_SPEED` - Set the fan speed of specified tool or current tool if no `P` is supplied. Then save to be recovered at ToolChange.
   * `S` - Fan speed 0-255 or 0-1, default is 1, full speed.
@@ -110,7 +111,6 @@ This command can be used without any additional parameters. Without parameters i
     * Use for example 0.1 to change immediately to standby temperature.
   * `SHTDWN_TIMEOUT` - Time in seconds to wait from docking tool to shutting off the heater, optional.
     * Use for example 86400 to wait 24h if you want to disable shutdown timer.
-* `Tn` - T0, T1, T2, etc... A select command is created for each tool.
 * `SET_GLOBAL_OFFSET` - Set a global offset that can be applied to all tools
   * `X` / `Y` / `Z` - Set the X/Y/Z offset position
   * `X_ADJUST` / `Y_ADJUST` / `Z_ADJUST` - Adjust the X/Y/Z offset position incramentally

--- a/tool.py
+++ b/tool.py
@@ -30,6 +30,15 @@ class Tool:
         self.idle_to_standby_time = 30      # Time in seconds from being parked to setting temperature to standby the temperature above. Use 0.1 to change imediatley to standby temperature. Requred on Physical tool
         self.idle_to_powerdown_time = 600   # Time in seconds from being parked to setting temperature to 0. Use something like 86400 to wait 24h if you want to disable. Requred on Physical tool.
 
+        # Tool specific input shaper parameters. Initiated as Klipper standard.
+        self.shaper_freq_x = 0
+        self.shaper_freq_y = 0
+        self.shaper_type_x = "mzv"
+        self.shaper_type_y = "mzv"
+        self.shaper_damping_ratio_x = 0.1
+        self.shaper_damping_ratio_y = 0.1
+
+        # Under Development:
         HeatMultiplyerAtFullFanSpeed = 1    # Multiplier to be aplied to hotend temperature when fan is at maximum. Will be multiplied with fan speed. Ex. 1.1 at 205*C and fan speed of 40% will set temperature to 213*C
 
         # If called without config then just return a dummy object.
@@ -234,6 +243,19 @@ class Tool:
             self.gcode.run_script_from_command(
                 "SET_FAN_SPEED FAN=" + self.fan + " SPEED=" + str(self.toollock.get_saved_fan_speed()) )
 
+        # Set Tool specific input shaper.
+        if self.shaper_freq_x != 0 or self.shaper_freq_y != 0:
+            cmd = ("SET_INPUT_SHAPER" +
+                " SHAPER_FREQ_X=" + str(self.shaper_freq_x) +
+                " SHAPER_FREQ_Y=" + str(self.shaper_freq_y) +
+                " DAMPING_RATIO_X=" + str(self.shaper_damping_ratio_x) +
+                " DAMPING_RATIO_Y=" + str(self.shaper_damping_ratio_y) +
+                " SHAPER_TYPE_X=" + str(self.shaper_type_x) +
+                " SHAPER_TYPE_Y=" + str(self.shaper_type_y) )
+            self.gcode.respond_info("Pickup: " + cmd)
+            self.gcode.run_script_from_command(cmd)
+
+        # Save current picked up tool and print on screen.
         self.toollock.SaveCurrentTool(self.name)
         self.gcode.run_script_from_command("M117 T%d picked up." % (self.name))
 
@@ -361,7 +383,13 @@ class Tool:
             "heater_active_temp": self.heater_active_temp,
             "heater_standby_temp": self.heater_standby_temp,
             "idle_to_standby_time": self.idle_to_standby_time,
-            "idle_to_powerdown_time": self.idle_to_powerdown_time
+            "idle_to_powerdown_time": self.idle_to_powerdown_time,
+            "shaper_freq_x": self.shaper_freq_x,
+            "shaper_freq_y": self.shaper_freq_y,
+            "shaper_type_x": self.shaper_type_x,
+            "shaper_type_y": self.shaper_type_y,
+            "shaper_damping_ratio_x": self.shaper_damping_ratio_x,
+            "shaper_damping_ratio_y": self.shaper_damping_ratio_y
         }
         return status
 


### PR DESCRIPTION
Because every tool can be very different, now we can specify different input shaper parameters for each tool. Not usable on virtual tools.