### PR TITLE
Added RESTORE_POSITION and Several small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ toolchanger from RRF and Duet3 to Klipper.
 
 I welcome all contribution!
 
-This is still a work in progress. Treat it as a alpha version.
+This is working great but treat it as a Beta version in development.
 
 ## Features
 
@@ -45,6 +45,7 @@ parameter to specify another tool.
   - Wait to reach temperature with tolerance. Set temperature +/- configurable tolerance.
 * Current Tool is saved and restored at powerdown. Default but optional.
 * Input shaper parameters for each tool.
+* Position prior to toolchange can optionaly be saved and restored.
 
 ## Installation Instructions
 ### Install with Moonraker Autoupdate Support
@@ -82,11 +83,10 @@ cp ./*.py ~/klipper/klippy/extras/
 Then restart Klipper to pick up the extensions.
 
 ## To do:
-* Change virtual tools code.
+* Add virtual tools select code.
 * Add selectable automatic calculation of active times based on previous times. Ex:
   * Mean Layer time Standby mode. - Save time at every layerchange and at toolchange set to mean time of last 3 layers *2 or at last layer *1.5 with a Maximum and a minimum time. Needs to be analyzed further.
   * Save the time it was in Standby last time and apply a fuzzfactor. Put tool in standby and heatup with presumption that next time will be aproximatley after the same time as last. +/- Fuzzfactor.
-* Implement Fan Scale. Can change fan scale for diffrent materials or tools from slicer at toolchange. Maybe max and min too?
 * Save pressure avance per tool to be restored on toolchange. Also between virtual tools. Check Slicer output first if this is needed or can be put in Filament custom gcode.
 
 ## Configuration requirements
@@ -95,7 +95,8 @@ Then restart Klipper to pick up the extensions.
 ## G-Code commands:
 * `TOOL_LOCK` - Lock command
 * `TOOL_UNLOCK` - Unlock command
-* `Tn` - T0, T1, T2, etc... A select command is created for each tool.
+* `Tn` - T0, T1, T2, etc... A select command is created for each tool. 
+  * `RESTORE_POSITION` - Optional that will save position and type of restore, Defaults to 0, do not restore, 1will restore XY and 2 will restore XYZ withe the `RESTORE_POSITION` command.
 * `T_1` - Dropoff the current tool without picking up another tool
 * `SET_AND_SAVE_FAN_SPEED` - Set the fan speed of specified tool or current tool if no `P` is supplied. Then save to be recovered at ToolChange.
   * `S` - Fan speed 0-255 or 0-1, default is 1, full speed.
@@ -122,12 +123,16 @@ This command can be used without any additional parameters. Without parameters i
   * `X` / `Y` / `Z` - Set the X/Y/Z offset position
   * `X_ADJUST` /`Y_ADJUST` / `Z_ADJUST` - Adjust the X/Y/Z offset position incramentally  
 * `SET_PURGE_ON_TOOLCHANGE` - Sets a global variable that can disable all purging (can be used in macros) when loading/unloading. For example when doing a TAMV/ZTATP tool alignement.
+* `SAVE_POSITION` - Save the current G-Code position of the toolhead.
+* `RESTORE_POSITION` - Restore position to the latest saved position. RESTORE_POSITION parameter as in Tn.
 ## Values accesible from Macro for each object
 - **Toollock**
   - `global_offset` - Global offset.
   - `tool_current` - -2: Unknown tool locked, -1: No tool locked, 0: and up are toolnames.
   - `saved_fan_speed` - Speed saved at each fanspeedchange to be recovered at Toolchange.
   - `purge_on_toolchange` - For use in macros to enable/disable purge/wipe code globaly.
+  - `restore_position_on_toolchange` - If the latest T# command had a RESTORE_POSITION parameter to other than 0
+  - `saved_position` - The position saved when the latest T# command had a RESTORE_POSITION parameter to other than 0
 - **Tool** - The tool calling this macro is referenced as `myself` in macros. When running for example `T3` to pickup the physical tool, in `pickup_gcode:` of one can write `{myself.name}` which would return `3`.
   - `name` - id. 0, 1, 2, etc.
   - `is_virtual` - If this tool has another layer of toolchange possible.

--- a/config/example_complex/tool_macro.cfg
+++ b/config/example_complex/tool_macro.cfg
@@ -1,19 +1,12 @@
-[gcode_macro SUB_TOOL_PICKUP_DEPRESURIZE_HOTEND]
-description: Internal subroutine. Do not use!
-# Restore hotend pressure
-# Finishing up the Pickup.
-gcode:
-                                                                      # If temperature is above min extrude temp.
-    {% if printer[printer.toolhead.extruder].can_extrude|default('false')|lower == 'true' %}
-          G1 E0.8 F2400                                                 # Perform a deretract to return filament pressure. (40mm/s)
-    {% endif %}                                                       # /
-
 [gcode_macro TOOL_LOCK_CHECK]
 description: Check so the tool is mounted by slightly advancing the lock again until hit endstop, only if endstop not already hit. Do not wait for it to finish.
 gcode:
-  SET_TMC_CURRENT STEPPER=tool_lock CURRENT=1.0
-  MANUAL_STEPPER STEPPER=tool_lock Move=20 SPEED=50 STOP_ON_ENDSTOP=1 SYNC=0
-  SET_TMC_CURRENT STEPPER=tool_lock CURRENT=0.8
+  # If endstop is not triggered then try to lock again for safety. Best to check the endstops before calling this. 
+  {% if printer.query_endstops.last_query['manual_stepper tool_lock']|default(0) == 0 %}
+    SET_TMC_CURRENT STEPPER=tool_lock CURRENT=1.0
+    MANUAL_STEPPER STEPPER=tool_lock Move=20 SPEED=50 STOP_ON_ENDSTOP=1 SYNC=0
+    SET_TMC_CURRENT STEPPER=tool_lock CURRENT=0.8
+  {% endif %}
 
 
 [gcode_macro M106]
@@ -136,3 +129,18 @@ gcode:
 [gcode_macro TOOL_DROPOFF]
 gcode:
   T_1
+
+
+
+[gcode_macro SAVE_ACCELERATION]
+variable_max_accel: 0
+gcode:
+  SET_GCODE_VARIABLE MACRO=SAVE_ACCELERATION VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+
+[gcode_macro RESTORE_ACCELERATION]
+gcode:
+  {% if printer['gcode_macro SAVE_ACCELERATION'].max_accel|int == 0 %}
+    { action_respond_info("RESTORE_ACCELERATION: No acceleration saved.") }
+  {% else %}
+    M204 S{printer['gcode_macro SAVE_ACCELERATION'].max_accel}
+  {% endif %}

--- a/config/example_complex/tools.cfg
+++ b/config/example_complex/tools.cfg
@@ -8,7 +8,6 @@ filename:  ~/variables.cfg
 [toollock]
 purge_on_toolchange = True          # Here we can disable all purging. When disabled it overrides all other purge options. Defaults to true. This can be turned off by a macro for automatic probing hot tools without probing them. For example when doing TAMV or ZTATP.
 #init_printer_to_last_tool = True   #Initialise as it was turned off, unlock tool if none was loaded or lock if one was loaded. Defaults to True
-#wipetype: 0                         # WipeType number as defined by [toolwipetype n]. Overwrites setting in [toolgroup n] defaults to -1 which is No Wipe if not defined anywhere.
 tool_lock_gcode:
     SAVE_GCODE_STATE NAME=tool_unlock_state                                         # Save gcode state
     MANUAL_STEPPER STEPPER=tool_lock SET_POSITION=0                                 # Set assumed possition as rotated to min
@@ -57,17 +56,22 @@ extruder: extruder
 fan: partfan_t0
 zone: 550,5
 park: 598,5
-offset: 10.79,4.86,3.41
+offset: 11.406,3.778,3.537
 #####
 ##### Following can be inherited from ToolGroup if not specified for this tool or inherited from a Physical parent.
 #physical_parent:                  # Defaults to None.
 #is_virtual: False                 # Defaults to False
-meltzonelength: 18                 # Defaults to 0
+meltzonelength: 14 #18                 # Defaults to 0
 #####
 ##### Options below have no effect on Virtual tools.
-#idle_to_standby_time: 30          # Time in seconds from being parked to setting temperature to standby the temperature above. Use 0.1 to change imediatley to standby temperature. Defaults to 30
+idle_to_standby_time: 0.1          # Time in seconds from being parked to setting temperature to standby the temperature above. Use 0.1 to change imediatley to standby temperature. Defaults to 30
 #idle_to_powerdown_time: 600       # Time in seconds from being parked to setting temperature to 0. Use something like 86400 to wait 24h if you want to disable. Defaults to 600
 lazy_home_when_parking: 1           # (default: 0 - disabled) - When set to 1, will home unhomed XY axes if needed and will not move any axis if already homed and parked. 2 Will also home Z if not homed.
+shaper_freq_x: 137.2
+shaper_freq_y: 116.4
+shaper_type_x: 2hump_ei
+shaper_type_y: 2hump_ei
+
 #pickup_gcode= The code that is run when picking up the physical tool. Variable {myself} refers to the tool calling this code.
 pickup_gcode: 
   SUB_TOOL_PICKUP_START T={myself.name}
@@ -77,12 +81,25 @@ dropoff_gcode:
   SUB_TOOL_DROPOFF_START T={myself.name}
   SUB_TOOL_DROPOFF_END T={myself.name}
 
-#[tool 1]
-#tool_group: 0
+[tool 1]
+tool_group: 0
 
-#[tool 2]
-#tool_group: 0
+[tool 2]
+tool_group: 0
+[tool 3]
+tool_group: 0
+[tool 4]
+tool_group: 0
+[tool 5]
+tool_group: 0
+[tool 6]
+tool_group: 0
+[tool 7]
+tool_group: 0
+[tool 8]
+tool_group: 0
 
+# End of Tool 0 virtual tools.
 
 [tool 9]
 tool_group: 1
@@ -90,8 +107,13 @@ extruder: extruder1
 fan: partfan_t9
 zone: 550,100
 park: 598,100
-offset: 3.55,0.87,0.06
-meltzonelength: 18
+offset: -1.046,-0.220,-1.510
+meltzonelength: 14 #18
+idle_to_standby_time: 0.1
+shaper_freq_x: 126.8
+shaper_freq_y: 128.6
+shaper_type_x: 3hump_ei
+shaper_type_y: 3hump_ei
 
 [tool 10]
 tool_group: 1
@@ -99,15 +121,24 @@ extruder: extruder2
 fan: partfan_t10
 zone: 550,200
 park: 598,200
-offset: 10.79,4.86,3.41
-meltzonelength: 18
-
+offset: 12.069,4.472,3.180
+meltzonelength: 14 #18
+idle_to_standby_time: 0.1
+shaper_freq_x: 119.8
+shaper_freq_y: 126.6
+shaper_type_x: mzv
+shaper_type_y: 2hump_ei
 
 [tool 49]
 tool_group: 1
 zone: 560,515
 park: 598,515
 offset: 0,0,0
+# Just to reset the input shaper.
+#shaper_freq_x: 0
+#shaper_freq_y: 0
+#shaper_type_x: mzv
+#shaper_type_y: mzv
 
 [gcode_macro SUB_TOOL_PICKUP_START]
 description: Internal subroutine. Do not use!
@@ -116,6 +147,9 @@ gcode:
   {%set myself = printer['tool '~params.T]%}
 
   M568 P{myself.name} A2                                               # Put tool heater in Active mode
+
+  SAVE_ACCELERATION                                                    # Save current acceleration value.
+  M204 S8000                                                           # Set high acceleration for toolchanging
 
   SAVE_GCODE_STATE NAME=TOOL_PICKUP                                    # Save GCODE state. Will be restored at the end of SUB_TOOL_PICKUP_END
   SET_GCODE_VARIABLE MACRO=HOMING_STATUS VARIABLE=maxx VALUE=0         # Don't use the X-max endstop as EmergencyStop.
@@ -144,7 +178,7 @@ gcode:
   {% endif %}                                                          # /
 
   ##############  Move out to zone  ##############
-  G0 X{myself.zone[0]} F6000                                     # Slow Move to the zone position for tool.
+  G0 X{myself.zone[0]} F6000                                           # Slow Move to the zone position for tool.
 
 [gcode_macro SUB_TOOL_PICKUP_END]
 description: Internal subroutine. Do not use!
@@ -152,9 +186,10 @@ description: Internal subroutine. Do not use!
 gcode:
   {%set myself = printer['tool '~params.T]%}
     ##############  Move out to Safe position  ##############
-  G0 X500 F40000                                                 # Fast Move to the safe position for tools.
+  G0 X500 F40000                                                       # Fast Move to the safe position for tools.
 
     ##############  Check Tool Lock  ##############
+  QUERY_ENDSTOPS                                                       # Check the endstops and save the state to be retrieved in the macro below.
   TOOL_LOCK_CHECK                                                      # MAcro to check so the tool is mounted by slightly advancing the lock again until hit endstop, only if endstop not already hit. Do not wait for it to finish.
 
     ##############  Finnish up  ##############
@@ -164,17 +199,22 @@ gcode:
                                                                        # Set the toolhead offsets. Z is set and moved before any moves in SUB_TOOL_PICKUP_START. Needs to be after any RESTORE_GCODE_STATE!
   SET_GCODE_OFFSET X={myself.offset[0]} Y={myself.offset[1]} Z={myself.offset[2]} MOVE=0  # Set X and Y offsets, 
 
+    ##############  Return to saved position  ##############
+  G1 F40000
+  RESTORE_POSITION
+
   SAVE_GCODE_STATE NAME=TOOL_PICKUP2                            # Save state for priming nozzle
-  RESPOND MSG="First if:{myself.extruder|default("none")|lower}"
-  ##############  Prime the filament, asume it was retracted as per e3d Revo documentation  ##############
+#  RESPOND MSG="First if:{myself.extruder|default("none")|lower}"
+
+    ##############  Prime the filament, asume it was retracted as per e3d Revo documentation  ##############
   {% if myself.extruder|default("none")|lower !="none" %}       # If the tool has an extruder:
-    RESPOND MSG="First if1:{myself.extruder|default("none")|lower}"
-    RESPOND MSG="Second if:{printer[myself.extruder].can_extrude|default("false")|lower}"
-    RESPOND MSG="Second if1:{printer.toollock.purge_on_toolchange}"
+#    RESPOND MSG="First if1:{myself.extruder|default("none")|lower}"
+#    RESPOND MSG="Second if:{printer[myself.extruder].can_extrude|default("false")|lower}"
+#    RESPOND MSG="Second if1:{printer.toollock.purge_on_toolchange}"
                                                                   # If can extrude and global purge is active:
     {% if printer[myself.extruder].can_extrude|default("false")|lower == 'true' and printer.toollock.purge_on_toolchange %}
-      RESPOND MSG="Second if2:{printer[myself.extruder].can_extrude|default("false")|lower}"
-      RESPOND MSG="Second if3:{printer.toollock.purge_on_toolchange}"
+#      RESPOND MSG="Second if2:{printer[myself.extruder].can_extrude|default("false")|lower}"
+#      RESPOND MSG="Second if3:{printer.toollock.purge_on_toolchange}"
       M83                                                           # Relative extrusion
       G1 E{myself.meltzonelength|int - 2} F1300                     # DeRetract filament from meltzone
       G1 E2 F400                                                    # DeRetract filament from meltzone
@@ -182,6 +222,7 @@ gcode:
   {% endif %}
   RESTORE_GCODE_STATE NAME=TOOL_PICKUP2                          # Restore state after priming nozzle
   G1 F30000
+  RESTORE_ACCELERATION                                           # Restore saved acceleration value.
 
 
 
@@ -191,17 +232,17 @@ description: Internal subroutine. Do not use!
 gcode:
   {%set myself = printer['tool '~params.T]%}
 
+  SAVE_ACCELERATION                                            # Save current acceleration value.
+  M204 S8000                                                   # Set high acceleration for toolchanging
+
   {% if myself.name|int != printer.toollock.tool_current|int %}
     { action_raise_error("SUB_TOOL_DROPOFF_START: Wrong tool. Asked to dropoff T" ~ myself.name ~ " while current is T" ~ printer.toollock.tool_current ~ ".") }
   {% endif %}
-
-  RESPOND MSG="Will drop off T{myself.name} at X{myself.park[0]} Y{myself.park[1]}"
 
     ##############  Retract the filament as per e3d Revo documentation  ##############
   {% if myself.extruder|default("none")|lower !="none" %}       # If the tool has an extruder:
     M568 P{myself.name} A1                                        # Put tool heater in standby
 
-                                                                  # If can extrude and global purge is active:
     {% if printer[myself.extruder].can_extrude|default("false")|lower == 'true' and printer.toollock.purge_on_toolchange %}
       M83                                                           # Relative extrusion
       G1 E-4 F2700                                                  # retract filament from meltzone
@@ -244,3 +285,4 @@ gcode:
 
   SET_GCODE_VARIABLE MACRO=HOMING_STATUS VARIABLE=maxx VALUE=1 # Use the X max as EmergencyStop.
   RESTORE_GCODE_STATE NAME=TOOL_DROPOFF_002 MOVE=0   # Restore Gcode state
+  RESTORE_ACCELERATION                # Restore saved acceleration value.

--- a/toolgroup.py
+++ b/toolgroup.py
@@ -24,7 +24,6 @@ class ToolGroup:
        # -1 = none, 1= Only load filament, 2= Wipe in front of carriage, 3= Pebble wiper, 4= First Silicone, then pebble. Defaults to 0.
         self.pickup_gcode = config.get('pickup_gcode', '')
         self.dropoff_gcode = config.get('dropoff_gcode', '')
-        self.lazy_home_when_parking = config.get('lazy_home_when_parking', 0)                      # 0 = none, 1= Only load filament, 2= Wipe in front of carriage, 3= Pebble wiper, 4= First Silicone, then pebble. Defaults to 0.
         self.meltzonelength = config.get('meltzonelength', 0)
         self.idle_to_standby_time = config.getfloat( 'idle_to_standby_time', 30, minval = 0.1)
         self.idle_to_powerdown_time = config.getfloat( 'idle_to_powerdown_time', 600, minval = 0.1)

--- a/toollock.py
+++ b/toollock.py
@@ -366,7 +366,8 @@ class ToolLock:
             "tool_current": self.tool_current,
             "saved_fan_speed": self.saved_fan_speed,
             "purge_on_toolchange": self.purge_on_toolchange,
-            "restore_position_on_toolchange": self.restore_position_on_toolchange
+            "restore_position_on_toolchange": self.restore_position_on_toolchange,
+            "saved_position": self.saved_position
         }
         return status
 

--- a/toollock.py
+++ b/toollock.py
@@ -20,27 +20,26 @@ class ToolLock:
             'init_printer_to_last_tool', True)
         self.purge_on_toolchange = config.getboolean(
             'purge_on_toolchange', True)
+        self.saved_position = None
+        self.restore_position_on_toolchange = 0   # 0: Don't restore; 1: Restore XY; 2: Restore XYZ
 
         # G-Code macros
         self.tool_lock_gcode_template = gcode_macro.load_template(config, 'tool_lock_gcode', '')
         self.tool_unlock_gcode_template = gcode_macro.load_template(config, 'tool_unlock_gcode', '')
 
         # Register commands
-        self.gcode.register_command("SAVE_CURRENT_TOOL", self.cmd_SAVE_CURRENT_TOOL, desc=self.cmd_SAVE_CURRENT_TOOL_help)
-        self.gcode.register_command("TOOL_LOCK", self.cmd_TOOL_LOCK, desc=self.cmd_TOOL_LOCK_help)
-        self.gcode.register_command("TOOL_UNLOCK", self.cmd_TOOL_UNLOCK, desc=self.cmd_TOOL_UNLOCK_help)
-        self.gcode.register_command("T_1", self.cmd_T_1, desc=self.cmd_T_1_help)
-        self.gcode.register_command("SET_AND_SAVE_FAN_SPEED", self.cmd_SET_AND_SAVE_FAN_SPEED, desc=self.cmd_SET_AND_SAVE_FAN_SPEED_help)
-        self.gcode.register_command("TEMPERATURE_WAIT_WITH_TOLERANCE", self.cmd_TEMPERATURE_WAIT_WITH_TOLERANCE, desc=self.cmd_TEMPERATURE_WAIT_WITH_TOLERANCE_help)
-        self.gcode.register_command("SET_TOOL_TEMPERATURE", self.cmd_SET_TOOL_TEMPERATURE, desc=self.cmd_SET_TOOL_TEMPERATURE_help)
-        self.gcode.register_command("SET_GLOBAL_OFFSET", self.cmd_SET_GLOBAL_OFFSET, desc=self.cmd_SET_GLOBAL_OFFSET_help)
-        self.gcode.register_command("SET_TOOL_OFFSET", self.cmd_SET_TOOL_OFFSET, desc=self.cmd_SET_TOOL_OFFSET_help)   
-        self.gcode.register_command("SET_PURGE_ON_TOOLCHANGE", self.cmd_SET_PURGE_ON_TOOLCHANGE, desc=self.cmd_SET_PURGE_ON_TOOLCHANGE_help)
+        handlers = [
+            'SAVE_CURRENT_TOOL', 'TOOL_LOCK', 'TOOL_UNLOCK',
+            'T_1', 'SET_AND_SAVE_FAN_SPEED', 'TEMPERATURE_WAIT_WITH_TOLERANCE', 
+            'SET_TOOL_TEMPERATURE', 'SET_GLOBAL_OFFSET', 'SET_TOOL_OFFSET',
+            'SET_PURGE_ON_TOOLCHANGE', 'SAVE_POSITION', 'RESTORE_POSITION']
+        for cmd in handlers:
+            func = getattr(self, 'cmd_' + cmd)
+            desc = getattr(self, 'cmd_' + cmd + '_help', None)
+            self.gcode.register_command(cmd, func, False, desc)
 
-        self.gcode.register_mux_command("TEST_PY", "EXTRUDER", None, self.cmd_test_py)
-        
         self.printer.register_event_handler("klippy:ready", self.Initialize_Tool_Lock)
-
+        
     cmd_TOOL_LOCK_help = "Lock the ToolLock."
     def cmd_TOOL_LOCK(self, gcmd = None):
         self.ToolLock()
@@ -133,7 +132,7 @@ class ToolLock:
             self.gcode.respond_info("cmd_SET_AND_SAVE_FAN_SPEED: Invalid tool:"+str(tool_id))
             return None
 
-        self.gcode.respond_info("ToolLock.cmd_SET_AND_SAVE_FAN_SPEED: Change fan speed for T%d to %f." % (tool_id, fanspeed))
+        self.gcode.respond_info("ToolLock.cmd_SET_AND_SAVE_FAN_SPEED: Change fan speed for T%s to %f." % (str(tool_id), fanspeed))
 
         # If value is >1 asume it is given in 0-255 and convert to percentage.
         if fanspeed > 1:
@@ -150,7 +149,7 @@ class ToolLock:
         tool = self.printer.lookup_object("tool " + str(tool_id))
 
         if tool.fan is None:
-            self.gcode.respond_info("ToolLock.SetAndSaveFanSpeed: Tool %d has no fan." % tool_id)
+            self.gcode.respond_info("ToolLock.SetAndSaveFanSpeed: Tool %s has no fan." % str(tool_id))
         else:
             self.SaveFanSpeed(fanspeed)
             self.gcode.run_script_from_command(
@@ -239,7 +238,7 @@ class ToolLock:
             return None
 
         if self.printer.lookup_object("tool " + str(tool_id)).get_status()["extruder"] is None:
-            self.gcode.respond_info("cmd_SET_TOOL_TEMPERATURE: T%d has no extruder! Nothing to do." % tool_id )
+            self.gcode.respond_info("cmd_SET_TOOL_TEMPERATURE: T%s has no extruder! Nothing to do." % str(tool_id) )
             return None
 
         tool = self.printer.lookup_object("tool " + str(tool_id))
@@ -324,30 +323,50 @@ class ToolLock:
             self.purge_on_toolchange = True
         # self.gcode.respond_info("SET_PURGE_ON_TOOLCHANGE running: " + str(self.purge_on_toolchange))
 
-    def cmd_test_py(self, gcmd):
-        curtime = self.printer.get_reactor().monotonic()
-        toolhead = self.printer.lookup_object('toolhead')
-        homed = toolhead.get_status(curtime)['homed_axes']
-        gcmd.respond_info("homed:" + str(homed))
-        
     def SaveFanSpeed(self, fanspeed):
         self.saved_fan_speed = float(fanspeed)
        
-    def get_tool_current(self):
-        return self.tool_current
+    def Set_restore_position_on_toolchange(self, value):
+        self.restore_position_on_toolchange = value
 
-    def get_saved_fan_speed(self):
-        return self.saved_fan_speed
+    cmd_SAVE_POSITION_help = "Save the current G-Code position."
+    def cmd_SAVE_POSITION(self, gcmd):
+        self.SavePosition()
 
-    def get_purge_on_toolchange(self):
-        return self.purge_on_toolchange
+    def SavePosition(self):
+        gcode_move = self.printer.lookup_object('gcode_move')
+        self.saved_position = gcode_move._get_gcode_position()
+
+    cmd_RESTORE_POSITION_help = "Restore a previously saved G-Code position if it was specified in the toolchange command, T1 RESTORE_POSITION=1"
+    def cmd_RESTORE_POSITION(self, gcmd):
+        self.gcode.respond_info("cmd_RESTORE_POSITION running: " + str(self.restore_position_on_toolchange))
+
+        if self.restore_position_on_toolchange == 0:
+            return
+
+        if self.saved_position is None:
+            raise gcmd.error("No saved g-code position.")
+
+        try:
+            p = self.saved_position
+            if self.restore_position_on_toolchange == 1:
+                v=str("G1 X%.3f Y%.3f" % (p[0], p[1]))
+            elif self.restore_position_on_toolchange == 2:
+                v=str("G1 X%.3f Y%.3f Z%.3f" % (p[0], p[1], p[2]))
+            # Restore position
+            self.gcode.respond_info("cmd_RESTORE_POSITION running: " + v)
+            self.gcode.run_script_from_command(v)
+        except:
+            raise gcmd.error("Could not restore position.")
+
 
     def get_status(self, eventtime= None):
         status = {
             "global_offset": self.global_offset,
             "tool_current": self.tool_current,
             "saved_fan_speed": self.saved_fan_speed,
-            "purge_on_toolchange": self.purge_on_toolchange 
+            "purge_on_toolchange": self.purge_on_toolchange,
+            "restore_position_on_toolchange": self.restore_position_on_toolchange
         }
         return status
 


### PR DESCRIPTION
- Added parameter RESTORE_POSITION to T# command. Defaults to 0 to not save current position. If not 0, then it will save current position before toolchange and the position can restored inside the toolchange macros.
- Add toollock.saved_position and toollock.restore_position_on_toolchange.
- Add RESTORE_POSITION G-Code command that will issue a G1 to the saved XYS position. See new documentation.
- Change standby timer default from 30s to 0.1s, instantly change to standby temperature when putting the tool in standby.
- When changing to a tool with a extruder, the active temp of new tool will be selected before actual toolchange so it will heat up while unmounting loaded tool, thus speeding up total toolchange time.
- Removed the internal get_saved_fan_speed command in toollock and use the commo status to retrieve it.
-Remove duplicate lazy_home_when_parking in ToolGroup definition.
- Rewrote definition of handlers in toollock.
- Added retyping of tool_id to string in all error messages.
- Remove the unused cmd_test_py, get_purge_on_toolchange and get_tool_current command.