### PR TITLE
Devmerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,33 @@ This command can be used without any additional parameters. Without parameters i
   * `X` / `Y` / `Z` - Set the X/Y/Z offset position
   * `X_ADJUST` /`Y_ADJUST` / `Z_ADJUST` - Adjust the X/Y/Z offset position incramentally  
 * `SET_PURGE_ON_TOOLCHANGE` - Sets a global variable that can disable all purging (can be used in macros) when loading/unloading. For example when doing a TAMV/ZTATP tool alignement.
-* `SAVE_POSITION` - Save the current G-Code position of the toolhead.
-* `RESTORE_POSITION` - Restore position to the latest saved position. RESTORE_POSITION parameter as in Tn. This command is usually used inside the pickup_gcode script.
+* `SAVE_POSITION` - Sets the Restore type and saves specified position for the toolhead. This command is usually used inside the custom g-code of the slicer software. The restore_position_on_toolchange_type will be changed to reflect the passed parameters.
+  * X= X position to save, optional but Y must be specifie or this will be ignored.
+  * Y= Y position to save, optional but X must be specifie or this will be ignored.
+  * Z= Z position to save, optional but X and Y must be specifie or this will be ignored.
+    * With no parameters it will set Restore type to 0, no restore.
+    * With X and Y parameters it will save the specified X and Y. Sets restore type to 1, restore XY.
+    * With X, Y and Z parameters it will save the specified X, Y and Z. Sets restore type to 2, restore XYZ.
+* `SAVE_CURRENT_POSITION` - Save the current G-Code position of the toolhead. This command is usually used inside the pickup_gcode script or the custom g-code of the slicer software.
+  * RESTORE_POSITION_TYPE= Type of restore, optional. If not specified, restore_position_on_toolchange_type will not be changed.
+    * 0: No restore
+    * 1: Restore XY
+    * 2: Restore XYZ
+* `RESTORE_POSITION` - Restore position to the latest saved position. This command is usually used inside the pickup_gcode script.
+  * RESTORE_POSITION_TYPE= Type of restore, optional. If not specified, restore_position_on_toolchange_type will be used.
+    * 0: No restore
+    * 1: Restore XY
+    * 2: Restore XYZ
 ## Values accesible from Macro for each object
 - **Toollock**
   - `global_offset` - Global offset.
   - `tool_current` - -2: Unknown tool locked, -1: No tool locked, 0: and up are toolnames.
   - `saved_fan_speed` - Speed saved at each fanspeedchange to be recovered at Toolchange.
   - `purge_on_toolchange` - For use in macros to enable/disable purge/wipe code globaly.
-  - `restore_position_on_toolchange` - If the latest T# command had a RESTORE_POSITION parameter to other than 0
+  - `restore_position_on_toolchange_type` - The type of restore position:
+    - 0: No restore
+    - 1: Restore XY
+    - 2: Restore XYZ
   - `saved_position` - The position saved when the latest T# command had a RESTORE_POSITION parameter to other than 0
 - **Tool** - The tool calling this macro is referenced as `myself` in macros. When running for example `T3` to pickup the physical tool, in `pickup_gcode:` of one can write `{myself.name}` which would return `3`.
   - `name` - id. 0, 1, 2, etc.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Then restart Klipper to pick up the extensions.
 * `TOOL_LOCK` - Lock command
 * `TOOL_UNLOCK` - Unlock command
 * `Tn` - T0, T1, T2, etc... A select command is created for each tool. 
-  * `RESTORE_POSITION_TYPE` - Optional parameter that will save position and type of restore, Defaults to not changing anything, 0 to not restore, 1 will restore XY to current position and 2 will restore XYZ to current position with the `RESTORE_POSITION` command, see below.
+  * `R` - Calls SAVE_CURRENT_POSITION with the variable as a RESTORE_POSITION_TYPE. For example "T0 R1" will call "SAVE_CURRENT_POSITION RESTORE_POSITION_TYPE=1" before moving. Positioned is restored with "RESTORE_POSITION" from below.
 * `T_1` - Dropoff the current tool without picking up another tool
 * `SET_AND_SAVE_FAN_SPEED` - Set the fan speed of specified tool or current tool if no `P` is supplied. Then save to be recovered at ToolChange.
   * `S` - Fan speed 0-255 or 0-1, default is 1, full speed.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Then restart Klipper to pick up the extensions.
 * `TOOL_LOCK` - Lock command
 * `TOOL_UNLOCK` - Unlock command
 * `Tn` - T0, T1, T2, etc... A select command is created for each tool. 
-  * `RESTORE_POSITION` - Optional parameter that will save position and type of restore, Defaults to 0, do not restore, 1 will restore XY and 2 will restore XYZ with the `RESTORE_POSITION` command, see below.
+  * `RESTORE_POSITION_TYPE` - Optional parameter that will save position and type of restore, Defaults to not changing anything, 0 to not restore, 1 will restore XY to current position and 2 will restore XYZ to current position with the `RESTORE_POSITION` command, see below.
 * `T_1` - Dropoff the current tool without picking up another tool
 * `SET_AND_SAVE_FAN_SPEED` - Set the fan speed of specified tool or current tool if no `P` is supplied. Then save to be recovered at ToolChange.
   * `S` - Fan speed 0-255 or 0-1, default is 1, full speed.

--- a/tool.py
+++ b/tool.py
@@ -183,11 +183,12 @@ class Tool:
             #pass
 
         # If optional RESTORE_POSITION_TYPE parameter is passed as 1 or 2 then save current position and restore_position_on_toolchange_type as passed. Otherwise do not change either the restore_position_on_toolchange_type or saved_position. This makes it possible to call SAVE_POSITION or SAVE_CURRENT_POSITION before the actual T command.
-        param = gcmd.get_int('RESTORE_POSITION_TYPE', 0, minval=0, maxval=2)
-        if restore_position_type in [ 1, 2 ]:
-            self.toollock.SaveCurrentPosition(param)
-#        else:
-#            self.toollock.SavePosition()  # Sets restore_position_on_toolchange_type to 0
+        param = gcmd.get_int('RESTORE_POSITION_TYPE', None, minval=0, maxval=2)
+        if param is not None:
+            if restore_position_type in [ 1, 2 ]:
+                self.toollock.SaveCurrentPosition(param) # Sets restore_position_on_toolchange_type to 1 or 2 and saves current position
+            else:
+                self.toollock.SavePosition()  # Sets restore_position_on_toolchange_type to 0
 
         # Drop any tools already mounted.
         if current_tool_id >= 0:                    # If there is a current tool already selected and it's a dropable.

--- a/tool.py
+++ b/tool.py
@@ -183,9 +183,9 @@ class Tool:
             #pass
 
         # If optional RESTORE_POSITION_TYPE parameter is passed as 1 or 2 then save current position and restore_position_on_toolchange_type as passed. Otherwise do not change either the restore_position_on_toolchange_type or saved_position. This makes it possible to call SAVE_POSITION or SAVE_CURRENT_POSITION before the actual T command.
-        param = gcmd.get_int('RESTORE_POSITION_TYPE', None, minval=0, maxval=2)
+        param = gcmd.get_int('R', None, minval=0, maxval=2)
         if param is not None:
-            if restore_position_type in [ 1, 2 ]:
+            if param in [ 1, 2 ]:
                 self.toollock.SaveCurrentPosition(param) # Sets restore_position_on_toolchange_type to 1 or 2 and saves current position
             else:
                 self.toollock.SavePosition()  # Sets restore_position_on_toolchange_type to 0

--- a/tool.py
+++ b/tool.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
-from types import NoneType
+
 
 class Tool:
     def __init__(self, config = None):
@@ -52,13 +52,13 @@ class Tool:
         self.toollock = self.printer.lookup_object('toollock')
 
         ##### Name #####
-        self.name = config.get_name().split()[-1]
-        if not unicode(self.name, 'utf-8').isnumeric():
+        try:
+            _, name = config.get_name().split(" ", 1)
+            self.name = int(name)
+        except ValueError:
             raise config.error(
                     "Name of section '%s' contains illegal characters. Use only integer tool number."
                     % (config.get_name()))
-        else:
-            self.name = int(self.name)
 
         ##### ToolGroup #####
         self.toolgroup = 'toolgroup ' + str(config.getint('tool_group'))

--- a/tool.py
+++ b/tool.py
@@ -182,12 +182,12 @@ class Tool:
             self.gcode.run_script_from_command("M568 P%d A2" % (int(self.name)))
             #pass
 
-        # Check if we have a passed GCODE parameter for Restore Position, if not then set it to false.
-        param = gcmd.get('RESTORE_POSITION', 0)
-        param = int(str(param)[-1])
-
-        if param != 0:
-            self.toollock.SaveCurrentPosition()
+        # If optional RESTORE_POSITION_TYPE parameter is passed as 1 or 2 then save current position and restore_position_on_toolchange_type as passed. Otherwise do not change either the restore_position_on_toolchange_type or saved_position. This makes it possible to call SAVE_POSITION or SAVE_CURRENT_POSITION before the actual T command.
+        param = gcmd.get_int('RESTORE_POSITION_TYPE', 0, minval=0, maxval=2)
+        if restore_position_type in [ 1, 2 ]:
+            self.toollock.SaveCurrentPosition(param)
+#        else:
+#            self.toollock.SavePosition()  # Sets restore_position_on_toolchange_type to 0
 
         # Drop any tools already mounted.
         if current_tool_id >= 0:                    # If there is a current tool already selected and it's a dropable.

--- a/tool.py
+++ b/tool.py
@@ -186,11 +186,8 @@ class Tool:
         param = gcmd.get('RESTORE_POSITION', 0)
         param = int(str(param)[-1])
 
-        self.toollock.Set_restore_position_on_toolchange(param)
-        self.gcode.respond_info("RESTORE_POSITION: " + str(param))
         if param != 0:
-            self.toollock.SavePosition()
-            self.gcode.respond_info("RESTORE_POSITION: saved")
+            self.toollock.SaveCurrentPosition()
 
         # Drop any tools already mounted.
         if current_tool_id >= 0:                    # If there is a current tool already selected and it's a dropable.

--- a/toolgroup.py
+++ b/toolgroup.py
@@ -8,10 +8,12 @@ import logging
 class ToolGroup:
     def __init__(self, config):
         self.printer = config.get_printer()
-        self.name = config.get_name().split(' ')[1]
         gcode_macro = self.printer.load_object(config, 'gcode_macro')
 
-        if not unicode(self.name, 'utf-8').isnumeric():
+        try:
+            _, name = config.get_name().split(' ', 1)
+            self.name = int(name)
+        except ValueError:
             raise config.error(
                     "Name of section '%s' contains illegal characters. Use only integer ToolGroup number."
                     % (config.get_name()))

--- a/toollock.py
+++ b/toollock.py
@@ -338,7 +338,7 @@ class ToolLock:
         param_X = gcmd.get_float('X', None)
         param_Y = gcmd.get_float('Y', None)
         param_Z = gcmd.get_float('Z', None)
-        SaveCurrentPosition(param_X, param_Y, param_Z):
+        self.SavePosition(param_X, param_Y, param_Z)
 
     def SavePosition(self, param_X = None, param_Y = None, param_Z = None):
         if param_X is None or param_Y is None:

--- a/toollock.py
+++ b/toollock.py
@@ -21,7 +21,7 @@ class ToolLock:
         self.purge_on_toolchange = config.getboolean(
             'purge_on_toolchange', True)
         self.saved_position = None
-        self.restore_position_on_toolchange = 0   # 0: Don't restore; 1: Restore XY; 2: Restore XYZ
+        self.restore_position_on_toolchange_type = 0   # 0: Don't restore; 1: Restore XY; 2: Restore XYZ
 
         # G-Code macros
         self.tool_lock_gcode_template = gcode_macro.load_template(config, 'tool_lock_gcode', '')
@@ -366,7 +366,7 @@ class ToolLock:
     def SaveCurrentPosition(self, restore_position_type = None):
         if restore_position_type is not None:
             if restore_position_type in [ 0, 1, 2 ]:
-                self.restore_position_on_toolchange_type = param
+                self.restore_position_on_toolchange_type = restore_position_type
         
         gcode_move = self.printer.lookup_object('gcode_move')
         self.saved_position = gcode_move._get_gcode_position()
@@ -397,7 +397,7 @@ class ToolLock:
             p = self.saved_position
             if self.restore_position_on_toolchange_type == 1:
                 v=str("G1 X%.3f Y%.3f" % (p[0], p[1]))
-            elif self.restore_position_on_toolchang_typee == 2:
+            elif self.restore_position_on_toolchange_type == 2:
                 v=str("G1 X%.3f Y%.3f Z%.3f" % (p[0], p[1], p[2]))
             # Restore position
             self.gcode.respond_info("cmd_RESTORE_POSITION running: " + v)

--- a/toollock.py
+++ b/toollock.py
@@ -359,8 +359,11 @@ class ToolLock:
     def cmd_SAVE_CURRENT_POSITION(self, gcmd):
         # Save optional RESTORE_POSITION_TYPE parameter to restore_position_on_toolchange_type variable.
         param = gcmd.get_int('RESTORE_POSITION_TYPE', None, minval=0, maxval=2)
-        if param is not None:
-            if param == 0 or param == 1 or param == 2:
+        self.SaveCurrentPosition(param)
+
+    def SaveCurrentPosition(self, restore_position_type = None):
+        if restore_position_type is not None:
+            if restore_position_type in [ 0, 1, 2 ]:
                 self.restore_position_on_toolchange_type = param
         
         gcode_move = self.printer.lookup_object('gcode_move')

--- a/toollock.py
+++ b/toollock.py
@@ -338,7 +338,9 @@ class ToolLock:
         param_X = gcmd.get_float('X', None)
         param_Y = gcmd.get_float('Y', None)
         param_Z = gcmd.get_float('Z', None)
-        
+        SaveCurrentPosition(param_X, param_Y, param_Z):
+
+    def SavePosition(self, param_X = None, param_Y = None, param_Z = None):
         if param_X is None or param_Y is None:
             self.restore_position_on_toolchange_type = 0
             return

--- a/toollock.py
+++ b/toollock.py
@@ -358,7 +358,7 @@ class ToolLock:
         param = gcmd.get_int('RESTORE_POSITION', None, minval=0, maxval=2)
 
         if param is not None:
-            if param == 0 or param == 1:
+            if param == 0 or param == 1 or param == 2:
                 self.restore_position_on_toolchange = param
 
         if self.restore_position_on_toolchange == 0:

--- a/toollock.py
+++ b/toollock.py
@@ -22,6 +22,7 @@ class ToolLock:
             'purge_on_toolchange', True)
         self.saved_position = None
         self.restore_position_on_toolchange_type = 0   # 0: Don't restore; 1: Restore XY; 2: Restore XYZ
+        self.LogLevel = config.getint('LogLevel', 0) # Level of Debug text to write to console. 0=None, 1=Some, 2=All. Defaults to 0.
 
         # G-Code macros
         self.tool_lock_gcode_template = gcode_macro.load_template(config, 'tool_lock_gcode', '')
@@ -46,17 +47,17 @@ class ToolLock:
         self.ToolLock()
 
     def ToolLock(self, ignore_locked = False):
-        self.gcode.respond_info("TOOL_LOCK running. ")
+        self.LogThis("TOOL_LOCK running. ")
         if not ignore_locked and int(self.tool_current) != -1:
-            self.gcode.respond_info("TOOL_LOCK is already locked with tool " + self.tool_current + ".")
+            self.LogThis("TOOL_LOCK is already locked with tool " + self.tool_current + ".", 0)
         else:
             self.tool_lock_gcode_template.run_gcode_from_command()
             self.SaveCurrentTool("-2")
-            self.gcode.respond_info("Locked")
+            self.LogThis("Locked")
 
     cmd_T_1_help = "Deselect all tools"
     def cmd_T_1(self, gcmd = None):
-        self.gcode.respond_info("T_1 running. ")# + gcmd.get_raw_command_parameters())
+        self.LogThis("T_1 running. ")# + gcmd.get_raw_command_parameters())
         if self.tool_current == "-2":
             raise self.printer.command_error("cmd_T_1: Unknown tool already mounted Can't park unknown tool.")
         if self.tool_current != "-1":
@@ -64,10 +65,10 @@ class ToolLock:
 
     cmd_TOOL_UNLOCK_help = "Unlock the ToolLock."
     def cmd_TOOL_UNLOCK(self, gcmd = None):
-        self.gcode.respond_info("TOOL_UNLOCK running. ")
+        self.LogThis("TOOL_UNLOCK running. ")
         self.tool_unlock_gcode_template.run_gcode_from_command()
         self.SaveCurrentTool(-1)
-        self.gcode.run_script_from_command("M117 ToolLock Unlocked.")
+        self.LogThis("ToolLock Unlocked.")
 
 
     def PrinterIsHomedForToolchange(self, lazy_home_when_parking =0):
@@ -104,7 +105,7 @@ class ToolLock:
         if not self.init_printer_to_last_tool:
             return None
 
-        self.gcode.respond_info("Initialize_Tool_Lock running.")
+        self.LogThis("Initialize_Tool_Lock running.")
         save_variables = self.printer.lookup_object('save_variables')
         try:
             self.tool_current = save_variables.allVariables["tool_current"]
@@ -115,13 +116,13 @@ class ToolLock:
 
         if str(self.tool_current) == "-1":
             self.cmd_TOOL_UNLOCK()
-            self.gcode.run_script_from_command("M117 ToolLock initialized unlocked")
+            self.LogThis("ToolLock initialized unlocked", 0)
 
         else:
             t = self.tool_current
             self.ToolLock(True)
             self.SaveCurrentTool(str(t))
-            self.gcode.run_script_from_command("M117 ToolLock initialized with T%s." % self.tool_current) 
+            self.LogThis("ToolLock initialized with T%s." % self.tool_current) 
 
     cmd_SET_AND_SAVE_FAN_SPEED_help = "Save the fan speed to be recovered at ToolChange."
     def cmd_SET_AND_SAVE_FAN_SPEED(self, gcmd):
@@ -130,10 +131,10 @@ class ToolLock:
 
         # The minval above doesn't seem to work.
         if tool_id < 0:
-            self.gcode.respond_info("cmd_SET_AND_SAVE_FAN_SPEED: Invalid tool:"+str(tool_id))
+            self.LogThis("cmd_SET_AND_SAVE_FAN_SPEED: Invalid tool:"+str(tool_id))
             return None
 
-        self.gcode.respond_info("ToolLock.cmd_SET_AND_SAVE_FAN_SPEED: Change fan speed for T%s to %f." % (str(tool_id), fanspeed))
+        self.LogThis("ToolLock.cmd_SET_AND_SAVE_FAN_SPEED: Change fan speed for T%s to %f." % (str(tool_id), fanspeed))
 
         # If value is >1 asume it is given in 0-255 and convert to percentage.
         if fanspeed > 1:
@@ -150,7 +151,7 @@ class ToolLock:
         tool = self.printer.lookup_object("tool " + str(tool_id))
 
         if tool.fan is None:
-            self.gcode.respond_info("ToolLock.SetAndSaveFanSpeed: Tool %s has no fan." % str(tool_id))
+            self.LogThis("ToolLock.SetAndSaveFanSpeed: Tool %s has no fan." % str(tool_id), 0)
         else:
             self.SaveFanSpeed(fanspeed)
             self.gcode.run_script_from_command(
@@ -175,7 +176,7 @@ class ToolLock:
         tolerance = gcmd.get_int('TOLERANCE', 1, minval=0, maxval=50)
 
         if tool_id is not None and heater_id is not None:
-            self.gcode.respond_info("cmd_TEMPERATURE_WAIT_WITH_TOLERANCE: Can't use both P and H parameter at the same time.")
+            self.LogThis("cmd_TEMPERATURE_WAIT_WITH_TOLERANCE: Can't use both P and H parameter at the same time.", 0)
             return None
         elif tool_id is None and heater_id is None:
             tool_id = self.tool_current
@@ -205,14 +206,12 @@ class ToolLock:
                           )
         
         if target_temp > 40:                                # Only wait if set temperature is over 40*C
-            self.gcode.respond_info("Wait for heater " + heater_name + " to reach " + str(target_temp) + " with a tolerance of " + str(tolerance) + ".")
+            self.LogThis("Wait for heater " + heater_name + " to reach " + str(target_temp) + " with a tolerance of " + str(tolerance) + ".",1)
             self.gcode.run_script_from_command(
                 "TEMPERATURE_WAIT SENSOR=" + heater_name + 
                 " MINIMUM=" + str(target_temp - tolerance) + 
                 " MAXIMUM=" + str(target_temp + tolerance) )
-            self.gcode.respond_info("Wait for heater " + heater_name + " complete.")
-        #else:
-        #    self.gcode.respond_info("Not waiting for heater " + heater_name + " to reach " + str(target_temp) + " with a tolerance of " + str(tolerance) + ".")
+            self.LogThis("Wait for heater " + heater_name + " complete.")
 
 
     cmd_SET_TOOL_TEMPERATURE_help = "Waits for all temperatures, or a specified (TOOL) tool or (HEATER) heater's temperature within (TOLERANCE) tolerance."
@@ -234,12 +233,12 @@ class ToolLock:
         stdb_timeout = gcmd.get_float('STDB_TIMEOUT', None, minval=0)
         shtdwn_timeout = gcmd.get_float('SHTDWN_TIMEOUT', None, minval=0)
 
-        if tool_id < 0:
-            self.gcode.respond_info("cmd_SET_TOOL_TEMPERATURE: Tool " + str(tool_id) + " is not valid.")
+        if int(tool_id) < 0:
+            self.LogThis("cmd_SET_TOOL_TEMPERATURE: Tool " + str(tool_id) + " is not valid.",0)
             return None
 
         if self.printer.lookup_object("tool " + str(tool_id)).get_status()["extruder"] is None:
-            self.gcode.respond_info("cmd_SET_TOOL_TEMPERATURE: T%s has no extruder! Nothing to do." % str(tool_id) )
+            self.LogThis("cmd_SET_TOOL_TEMPERATURE: T%s has no extruder! Nothing to do." % str(tool_id), 1)
             return None
 
         tool = self.printer.lookup_object("tool " + str(tool_id))
@@ -269,7 +268,7 @@ class ToolLock:
         z_adjust = gcmd.get_float('Z_ADJUST', None)
 
         if tool_id < 0:
-            self.gcode.respond_info("cmd_SET_TOOL_TEMPERATURE: Tool " + str(tool_id) + " is not valid.")
+            self.LogThis("cmd_SET_TOOL_TEMPERATURE: Tool " + str(tool_id) + " is not valid.", 0)
             return None
 
         tool = self.printer.lookup_object("tool " + str(tool_id))
@@ -312,7 +311,7 @@ class ToolLock:
         elif z_adjust is not None:
             self.global_offset[2] = float(self.global_offset[2]) + float(z_adjust)
 
-        self.gcode.respond_info("Global offset now set to: %f, %f, %f." % (float(self.global_offset[0]), float(self.global_offset[1]), float(self.global_offset[2])))
+        self.LogThis("Global offset now set to: %f, %f, %f." % (float(self.global_offset[0]), float(self.global_offset[1]), float(self.global_offset[2])))
 
     cmd_SET_PURGE_ON_TOOLCHANGE_help = "Set the global variable if the tool should be purged or primed with filament at toolchange."
     def cmd_SET_PURGE_ON_TOOLCHANGE(self, gcmd = None):
@@ -379,7 +378,7 @@ class ToolLock:
 #    1: Restore XY
 #    2: Restore XYZ
     def cmd_RESTORE_POSITION(self, gcmd):
-        self.gcode.respond_info("cmd_RESTORE_POSITION running: " + str(self.restore_position_on_toolchange_type))
+        self.LogThis("cmd_RESTORE_POSITION running: " + str(self.restore_position_on_toolchange_type))
 
         param = gcmd.get_int('RESTORE_POSITION_TYPE', None, minval=0, maxval=2)
 
@@ -400,11 +399,15 @@ class ToolLock:
             elif self.restore_position_on_toolchange_type == 2:
                 v=str("G1 X%.3f Y%.3f Z%.3f" % (p[0], p[1], p[2]))
             # Restore position
-            self.gcode.respond_info("cmd_RESTORE_POSITION running: " + v)
+            self.LogThis("cmd_RESTORE_POSITION running: " + v)
             self.gcode.run_script_from_command(v)
         except:
             raise gcmd.error("Could not restore position.")
 
+    # Prints debugging text to console if configured Log level is higher than requested Log level.
+    def LogThis(self, dbgText, LogLevel=2):
+        if self.LogLevel >= LogLevel:
+            self.gcode.respond_info(dbgText)
 
     def get_status(self, eventtime= None):
         status = {
@@ -413,7 +416,8 @@ class ToolLock:
             "saved_fan_speed": self.saved_fan_speed,
             "purge_on_toolchange": self.purge_on_toolchange,
             "restore_position_on_toolchange_type": self.restore_position_on_toolchange_type,
-            "saved_position": self.saved_position
+            "saved_position": self.saved_position,
+            "LogLevel": self.LogLevel
         }
         return status
 


### PR DESCRIPTION
A bigger update having some changes mainly for position saving and restoring.
Also new configurable Debug level parameter to ToolLock. 

SAVE_POSITION functionality migrated to SAVE_CURRENT_POSITION. New functionality and parameters to SAVE_POSITION command. The RESTORE_POSITION parameter of T# command changed to to R.

For Tn command: If optional R parameter is passed as 1 or 2 then save current position and restore_position_on_toolchange_type as passed by the R parameter. Otherwise do not change either the restore_position_on_toolchange_type or saved_position. This makes it possible to call SAVE_POSITION or SAVE_CURRENT_POSITION before the actual T command.

- Added optional parameter RESTORE_POSITION_TYPE to cmd_SAVE_CURRENT_POSITION
- Change saved variable "restore_position_on_toolchange_type" to "restore_position_on_toolchange_type_type". Ading "_type" makes it more selfexplainatory.
- Added some description to cmd_SAVE_POSITION.
- Chenged parameter name for cmd_RESTORE_POSITION command from "RESTORE_POSITION" to "RESTORE_POSITION_TYPE" to make it more selfexplainatory.
- Add description to cmd_RESTORE_POSITION
- Defaults RESTORE_POSITION_TYPE of cmd_SelectTool to None, making it skip changing restore_position_on_toolchange_type
