### PR TITLE
Add files via upload

### DIFF
--- a/ktcclog.py
+++ b/ktcclog.py
@@ -119,11 +119,11 @@ class KtccLog:
 
     cmd_KTCC_G28_help = "Homing axes."
     def cmd_KTCC_G28(self, gcmd):
-        self.always("Starting G28")
+        # self.trace("Starting G28")
         self.save_active = False                    # Don't try to use SAVE_VARIABLE commands.
         self.prev_G28(gcmd)
         self.save_active = True                     # Resume to use SAVE_VARIABLE commands.
-        self.always("Ending G28")
+        # self.trace("Ending G28")
 
     def _save_changes_timer_event(self, eventtime):
         try:

--- a/ktcclog.py
+++ b/ktcclog.py
@@ -110,6 +110,8 @@ class KtccLog:
         # Need to do it outermost so that any G28 macros are used too.
         # When inside a G28 the parser won't run any SAVE_VARIABLE resulting in Klipper 
         try:
+            self.toolhead = self.printer.lookup_object('toolhead')
+
             self.prev_G28 = self.gcode.register_command("G28", None)
             self.gcode.register_command("G28", self.cmd_KTCC_G28, desc = self.cmd_KTCC_G28_help)
         except Exception as e:
@@ -117,9 +119,11 @@ class KtccLog:
 
     cmd_KTCC_G28_help = "Homing axes."
     def cmd_KTCC_G28(self, gcmd):
+        self.always("Starting G28")
         self.save_active = False                    # Don't try to use SAVE_VARIABLE commands.
         self.prev_G28(gcmd)
         self.save_active = True                     # Resume to use SAVE_VARIABLE commands.
+        self.always("Ending G28")
 
     def _save_changes_timer_event(self, eventtime):
         try:
@@ -300,20 +304,17 @@ class KtccLog:
     def track_mount_start(self, tool_id):
         self.trace("track_mount_start: Running for Tool: %s." % (tool_id))
         self._set_tool_statistics(tool_id, 'tracked_mount_start_time', time.time())
-        self.increase_tool_statistics(tool_id, 'toolmounts_started')
+        
 
     def track_mount_end(self, tool_id):
         self.trace("track_mount_end: Running for Tool: %s." % (tool_id))
         start_time = self.tool_statistics[str(tool_id)]['tracked_mount_start_time']
         if start_time is not None and start_time != 0:
-            self.trace("track_mount_end: start_time is not None for Tool: %s." % (tool_id))
+            # self.trace("track_mount_end: start_time is not None for Tool: %s." % (tool_id))
             time_spent = time.time() - start_time
             self.increase_tool_statistics(tool_id, 'total_time_spent_mounting', time_spent)
             self.total_time_spent_mounting += time_spent
             self._set_tool_statistics(tool_id, 'tracked_mount_start_time', 0)
-            
-            self.increase_tool_statistics(tool_id, 'toolmounts_completed')
-            self.total_toolmounts += 1
             self.changes_to_save = True
 
     def track_unmount_start(self, tool_id):
@@ -325,29 +326,37 @@ class KtccLog:
         self.trace("track_unmount_end: Running for Tool: %s." % (tool_id))
         start_time = self.tool_statistics[str(tool_id)]['tracked_unmount_start_time']
         if start_time is not None and start_time != 0:
-            self.trace("track_unmount_end: start_time is not None for Tool: %s." % (tool_id))
+            # self.trace("track_unmount_end: start_time is not None for Tool: %s." % (tool_id))
             time_spent = time.time() - start_time
             self.increase_tool_statistics(tool_id, 'total_time_spent_unmounting', time_spent)
             self.total_time_spent_unmounting += time_spent
             self._set_tool_statistics(tool_id, 'tracked_unmount_start_time', 0)
-            
             self.increase_tool_statistics(tool_id, 'toolunmounts_completed')
-            self.total_toolunmounts += 1
+            self.increase_statistics('total_toolunmounts')
             self.changes_to_save = True
 
-    def track_total_toolunlocks(self):
-        self.trace("track_total_toolunlocks: Running.")
-        self.total_toolunlocks += 1
-        self.changes_to_save = True
 
-    def track_total_toollocks(self):
-        self.trace("track_total_toollocks: Running.")
-        self.total_toollocks += 1
-        self.changes_to_save = True
+    def increase_statistics(self, key, count=1):
+        try:
+            self.trace("increase_statistics: Running. Provided to record tool stats while key: %s and count: %s" % (str(key), str(count)))
+            if key == 'total_toolmounts':
+                self.total_toolmounts += int(count)
+            elif key == 'total_toolunmounts':
+                self.total_toolunmounts += int(count)
+            elif key == 'total_toollocks':
+                self.total_toollocks += int(count)
+            elif key == 'total_toolunlocks':
+                self.total_toolunlocks += int(count)
+            self.changes_to_save = True
+        except Exception as e:
+            self.debug("Exception whilst tracking tool stats: %s" % str(e))
+            self.debug("increase_statistics: Error while increasing stats while key: %s and count: %s" % (str(key), str(count)))
 
     def track_selected_tool_start(self, tool_id):
         self.trace("track_selected_tool_start: Running for Tool: %s." % (tool_id))
         self._set_tool_statistics(tool_id, 'tracked_start_time_selected', time.time())
+        self.increase_statistics('total_toolmounts')
+        self.increase_tool_statistics(tool_id, 'toolmounts_completed')
 
     def track_selected_tool_end(self, tool_id):
         self.trace("track_selected_tool_end: Running for Tool: %s." % (tool_id))
@@ -418,13 +427,20 @@ class KtccLog:
             msg += "\n------------\n"
 
             msg += "Tool Statistics:\n"
-            for tool_id in self.tool_statistics:
-                # self.trace(str(tool))
+
+            # First convert to int so we get right order.
+            res = {int(k):v for k,v in self.tool_statistics.items()}
+            for tid in res:
+                tool_id= str(tid)
                 msg += "Tool#%s:\n" % (tool_id)
                 msg += "Completed %d out of %d mounts in %s. Average of %s per toolmount.\n" % (self.tool_statistics[tool_id]['toolmounts_completed'], self.tool_statistics[tool_id]['toolmounts_started'], self._seconds_to_human_string(self.tool_statistics[tool_id]['total_time_spent_mounting']), self._seconds_to_human_string(self._division(self.tool_statistics[tool_id]['total_time_spent_mounting'], self.tool_statistics[tool_id]['toolmounts_completed'])))
                 msg += "Completed %d out of %d unmounts in %s. Average of %s per toolunmount.\n" % (self.tool_statistics[tool_id]['toolunmounts_completed'], self.tool_statistics[tool_id]['toolunmounts_started'], self._seconds_to_human_string(self.tool_statistics[tool_id]['total_time_spent_unmounting']), self._seconds_to_human_string(self._division(self.tool_statistics[tool_id]['total_time_spent_unmounting'], self.tool_statistics[tool_id]['toolunmounts_completed'])))
-                msg += "%s spent selected. %s with active heater and %s with standby heater.\n" % (self._seconds_to_human_string(self.tool_statistics[tool_id]['time_selected']), self._seconds_to_human_string(self.tool_statistics[tool_id]['time_heater_active']), self._seconds_to_human_string(self.tool_statistics[tool_id]['time_heater_standby']))
-                msg += "------------\n"
+                msg += "%s spent selected." % self._seconds_to_human_string(self.tool_statistics[tool_id]['time_selected'])
+                tool = self.printer.lookup_object("tool " + str(tool_id))
+                if tool.is_virtual != True or tool.name==tool.physical_parent_id:
+                    if tool.extruder is not None:
+                        msg += " %s with active heater and %s with standby heater." % (self._seconds_to_human_string(self.tool_statistics[tool_id]['time_heater_active']), self._seconds_to_human_string(self.tool_statistics[tool_id]['time_heater_standby']))
+                msg += "\n------------\n"
                 
 
         self.always(msg)
@@ -436,8 +452,11 @@ class KtccLog:
             msg += "\n------------\n"
 
             msg += "Tool Statistics for this print:\n"
-            for tool_id in self.tool_statistics:
-                # self.trace(str(tool))
+
+            # First convert to int so we get right order.
+            res = {int(k):v for k,v in self.tool_statistics.items()}
+            for tid in res:
+                tool_id= str(tid)
                 ts = self.tool_statistics[tool_id]
                 pts = self.print_tool_statistics[tool_id]
                 msg += "Tool#%s:\n" % (tool_id)
@@ -459,11 +478,13 @@ class KtccLog:
             'total_toolmounts': self.total_toolmounts,
             'total_toolunmounts': self.total_toolunmounts
             }
+        self.toolhead.wait_moves()
         self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=%s VALUE=\"%s\"" % ("ktcc_statistics_swaps", swap_stats))
 
     def _persist_tool_statistics(self):
         for tool in self.tool_statistics:
             try:
+                self.toolhead.wait_moves()
                 self.gcode.run_script_from_command("SAVE_VARIABLE VARIABLE=%s%s VALUE=\"%s\"" % (self.KTCC_TOOL_STATISTICS_PREFIX, tool, self.tool_statistics[tool]))
             except Exception as err:
                 self.debug("Unexpected error in _persist_tool_statistics: %s" % err)
@@ -475,12 +496,12 @@ class KtccLog:
             if str(tool_id) in self.tool_statistics:
                 if self.tool_statistics[str(tool_id)][key] is None:
                     self.tool_statistics[str(tool_id)][key]=0
-                self.trace("increase_tool_statistics: Before running for Tool: %s. Key: %s is: %s" % (tool_id, str(key), str(self.tool_statistics[str(tool_id)][key])))
+                # self.trace("increase_tool_statistics: Before running for Tool: %s. Key: %s is: %s" % (tool_id, str(key), str(self.tool_statistics[str(tool_id)][key])))
                 if isinstance(count, float):
                     self.tool_statistics[str(tool_id)][key] = round(self.tool_statistics[str(tool_id)][key] + count, 3)
                 else:
                     self.tool_statistics[str(tool_id)][key] += count
-                self.trace("increase_tool_statistics: After running for Tool: %s. Key: %s is: %s" % (tool_id, str(key), str(self.tool_statistics[str(tool_id)][key])))
+                # self.trace("increase_tool_statistics: After running for Tool: %s. Key: %s is: %s" % (tool_id, str(key), str(self.tool_statistics[str(tool_id)][key])))
             else:
                 self.debug("increase_tool_statistics: Unknown tool provided to record tool stats: %s" % tool_id)
                 # self.debug(str(self.tool_statistics))
@@ -499,14 +520,14 @@ class KtccLog:
         except Exception as e:
             self.debug("Exception whilst tracking tool stats: %s" % str(e))
             self.debug("_set_tool_statistics: Error while tool: %s provided to record tool stats while key: %s and value: %s" % (tool_id, str(key), str(value)))
-        self.trace("_set_tool_statistics: Tool: %s provided to record tool stats while key: %s and value: %s" % (tool_id, str(key), str(value)))
+        # self.trace("_set_tool_statistics: Tool: %s provided to record tool stats while key: %s and value: %s" % (tool_id, str(key), str(value)))
 
     def _set_tool_statistics_time_diff(self, tool_id, final_time_key, start_time_key):
         try:
             if str(tool_id) in self.tool_statistics:
                 tool_stat= self.tool_statistics[str(tool_id)]
                 if tool_stat[start_time_key] is not None and tool_stat[start_time_key] != 0:
-                    self.trace("_set_tool_statistics_time_diff: Tool: %s value before running: final_time_key: %s=%s, start_time_key: %s=%s." % (tool_id, final_time_key, str(tool_stat[final_time_key]), start_time_key, str(tool_stat[start_time_key])))
+                    # self.trace("_set_tool_statistics_time_diff: Tool: %s value before running: final_time_key: %s=%s, start_time_key: %s=%s." % (tool_id, final_time_key, str(tool_stat[final_time_key]), start_time_key, str(tool_stat[start_time_key])))
                     if tool_stat[final_time_key] is not None and tool_stat[final_time_key] != 0:
                         tool_stat[final_time_key] += time.time() - tool_stat[start_time_key]
                     else:
@@ -517,16 +538,24 @@ class KtccLog:
         except Exception as e:
             self.debug("Exception whilst tracking tool stats: %s" % str(e))
             self.debug("_set_tool_statistics_time_diff: Error while tool: %s provided to record tool stats while final_time_key: %s and start_time_key: %s" % (tool_id, str(final_time_key), str(start_time_key)))
-        self.trace("_set_tool_statistics_time_diff: Tool: %s value after running: final_time_key: %s=%s, start_time_key: %s=%s." % (tool_id, final_time_key, str(tool_stat[final_time_key]), start_time_key, str(tool_stat[start_time_key])))
-        # self.trace("_set_tool_statistics_time_diff: Tool: %s provided to record tool stats while final_time_key: %s=%d and start_time_key: %s" % (tool_id, str(final_time_key), tool_stat[final_time_key], str(start_time_key)))
+        # self.trace("_set_tool_statistics_time_diff: Tool: %s value after running: final_time_key: %s=%s, start_time_key: %s=%s." % (tool_id, final_time_key, str(tool_stat[final_time_key]), start_time_key, str(tool_stat[start_time_key])))
 
 ### LOGGING AND STATISTICS FUNCTIONS GCODE FUNCTIONS
 
     cmd_KTCC_RESET_STATS_help = "Reset the KTCC statistics"
     def cmd_KTCC_RESET_STATS(self, gcmd):
-        self._reset_statistics()
-        self.changes_to_save = True
-        self._dump_statistics(True)
+        param = gcmd.get('SURE', "no")
+        if param.lower() == "yes":
+            self._reset_statistics()
+            self._reset_print_statistics()
+            self.changes_to_save = True
+            self._dump_statistics(True)
+            self.always("Statistics RESET.")
+        else:
+            message = "Are you sure you want to reset KTCC statistics?\n"
+            message += "If so, run with parameter SURE=YES:\n"
+            message += "KTCC_RESET_STATS SURE=YES"
+            self.gcode.respond_info(message)
 
     cmd_KTCC_DUMP_STATS_help = "Dump the KTCC statistics"
     def cmd_KTCC_DUMP_STATS(self, gcmd):

--- a/tool.py
+++ b/tool.py
@@ -14,13 +14,18 @@
 # ToolUnLock: Toollock is disengaged.
 
 # KTCC exception error class
-class KTCCError(Exception):
-    pass
+# class KTCCError(Exception):
+#     pass
 
 # Each tool is getting an instance of this.
+import logging
+
 class Tool:
     TOOL_UNKNOWN = -2
     TOOL_UNLOCKED = -1
+    HEATER_STATE_ACTIVE = 2
+    HEATER_STATE_STANDBY = 1
+    HEATER_STATE_OFF = 0
 
     def __init__(self, config = None):
         self.name = None
@@ -36,17 +41,25 @@ class Tool:
         self.park = None                    # Position to move to when fully parking the tool in the dock in the format X, Y
         self.offset = None                  # Offset of the nozzle in the format X, Y, Z
 
-        self.pickup_gcode = None            # The plain gcode string is to load for virtual tool having this tool as parent.
-        self.dropoff_gcode = None           # The plain gcode string is to load for virtual tool having this tool as parent.
+        self.pickup_gcode = None            # The plain gcode string for pickup of the tool.
+        self.dropoff_gcode = None           # The plain gcode string for droppoff of the tool.
         self.virtual_toolload_gcode = None  # The plain gcode string is to load for virtual tool having this tool as parent. This is for loading the virtual tool.
-        self.virtual_toolunload_gcode = None
+        self.virtual_toolunload_gcode = None# The plain gcode string is to unload for virtual tool having this tool as parent. This is for unloading the virtual tool.
 
+#        self.timer_idle_to_standby = None
+#        self.timer_idle_to_powerdown = None
 
-        self.heater_state = 0               # 0 = off, 1 = standby temperature, 2 = active temperature. Placeholder. Requred on Physical tool.
+        self.requires_pickup_for_virtual_load = None   # May be needed for a filament swap to prevent ooze but not for a pen.
+        self.requires_pickup_for_virtual_unload = None # May be needed for a filament swap to prevent ooze but not for a pen. Used when forcing unload.
+        self.unload_virtual_at_dropoff = None          # If it takes long time to unload/load it may be faster to leave it loaded and force unload at end of print.
+
+        self.virtual_loaded = -1            # The abstract tool loaded in the physical tool.
+        self.heater_state = 0               # 0 = off, 1 = standby temperature, 2 = active temperature. Placeholder.
+
         self.heater_active_temp = 0         # Temperature to set when in active mode. Placeholder. Requred on Physical and virtual tool if any has extruder.
         self.heater_standby_temp = 0        # Temperature to set when in standby mode.  Placeholder. Requred on Physical and virtual tool if any has extruder.
-        self.idle_to_standby_time = 0.1     # Time in seconds from being parked to setting temperature to standby the temperature above. Use 0.1 to change imediatley to standby temperature. Requred on Physical tool
-        self.idle_to_powerdown_time = 600   # Time in seconds from being parked to setting temperature to 0. Use something like 86400 to wait 24h if you want to disable. Requred on Physical tool.
+        self.idle_to_standby_time = None    # Time in seconds from being parked to setting temperature to standby the temperature above. Use 0.1 to change imediatley to standby temperature. Requred on Physical tool
+        self.idle_to_powerdown_time = None  # Time in seconds from being parked to setting temperature to 0. Use something like 86400 to wait 24h if you want to disable. Requred on Physical tool.
 
         # Tool specific input shaper parameters. Initiated as Klipper standard.
         self.shaper_freq_x = 0
@@ -56,8 +69,10 @@ class Tool:
         self.shaper_damping_ratio_x = 0.1
         self.shaper_damping_ratio_y = 0.1
 
-        # Under Development:
-        HeatMultiplyerAtFullFanSpeed = 1    # Multiplier to be aplied to hotend temperature when fan is at maximum. Will be multiplied with fan speed. Ex. 1.1 at 205*C and fan speed of 40% will set temperature to 213*C
+        self.config = config
+
+        # Under Consideration:
+        # HeatMultiplyerAtFullFanSpeed = 1    # Multiplier to be aplied to hotend temperature when fan is at maximum. Will be multiplied with fan speed. Ex. 1.1 at 205*C and fan speed of 40% will set temperature to 213*C
 
         # If called without config then just return a dummy object.
         if config is None:
@@ -66,7 +81,7 @@ class Tool:
         # Load used objects.
         self.printer = config.get_printer()
         self.gcode = self.printer.lookup_object('gcode')
-        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.gcode_macro = self.printer.load_object(config, 'gcode_macro')
         self.toollock = self.printer.lookup_object('toollock')
         self.log = self.printer.lookup_object('ktcclog')
 
@@ -90,7 +105,7 @@ class Tool:
                     % (config.get_name()))
         tg_status = self.toolgroup.get_status()
 
-        ##### Is Virtual #####
+       ##### Is Virtual #####
         self.is_virtual = config.getboolean('is_virtual', 
                                             tg_status["is_virtual"])
 
@@ -100,19 +115,18 @@ class Tool:
         if self.physical_parent_id is None:
             self.physical_parent_id = self.TOOL_UNLOCKED
 
+        if self.physical_parent_id >= 0 and not self.physical_parent_id == self.name:
+            self.pp = self.printer.lookup_object("tool " + str(self.physical_parent_id))
+        else:
+            self.pp = Tool()     # Initialize physical parent as a dummy object.
+
+        pp_status = self.pp.get_status()
+
         # Used as sanity check for tools that are virtual with same physical as themselves.
         if self.is_virtual and self.physical_parent_id == self.TOOL_UNLOCKED:
             raise config.error(
                     "Section Tool '%s' cannot be virtual without a valid physical_parent. If Virtual and Physical then use itself as parent."
                     % (config.get_name()))
-        
-        if self.physical_parent_id >= 0 and not self.physical_parent_id == self.name:
-            pp = self.printer.lookup_object("tool " + str(self.physical_parent_id))
-        else:
-            pp = Tool()     # Initialize physical parent as a dummy object.
-
-        pp_status = pp.get_status()
-
 
         ##### Extruder #####
         self.extruder = config.get('extruder', pp_status['extruder'])      
@@ -121,25 +135,39 @@ class Tool:
         self.fan = config.get('fan', pp_status['fan'])                     
 
         ##### Meltzone Length #####
-        self.meltzonelength = config.get('meltzonelength', pp_status['meltzonelength'])      
-        if self.meltzonelength is None:
-            self.meltzonelength = tg_status["meltzonelength"]
+        self.meltzonelength = self._get_config_parameter_with_inheritence('meltzonelength', 0)
 
         ##### Lazy Home when parking #####
-        self.lazy_home_when_parking = config.get('lazy_home_when_parking', pp_status['lazy_home_when_parking'])   
-        if self.lazy_home_when_parking is None:
-            self.lazy_home_when_parking = tg_status["lazy_home_when_parking"]
+        self.lazy_home_when_parking = self._get_bool_config_parameter_with_inheritence('lazy_home_when_parking', False)
 
         ##### Coordinates #####
-        self.zone = config.get('zone', pp_status['zone'])
-        if not isinstance(self.zone, list):
-            self.zone = str(self.zone).split(',')
-        self.park = config.get('park', pp_status['park'])                  
-        if not isinstance(self.park, list):
-            self.park = str(self.park).split(',')
-        self.offset = config.get('offset', pp_status['offset'])
-        if not isinstance(self.offset, list):
-            self.offset = str(self.offset).split(',')
+        try:
+            self.zone = config.get('zone', pp_status['zone'])
+            if not isinstance(self.zone, list):
+                self.zone = str(self.zone).split(',')
+            self.park = config.get('park', pp_status['park'])                  
+            if not isinstance(self.park, list):
+                self.park = str(self.park).split(',')
+            self.offset = config.get('offset', pp_status['offset'])
+            if not isinstance(self.offset, list):
+                self.offset = str(self.offset).split(',')
+
+            # Remove any accidental blank spaces.
+            self.zone = [s.strip() for s in self.zone]
+            self.park = [s.strip() for s in self.park]
+            self.offset = [s.strip() for s in self.offset]
+
+            if len(self.zone) < 3:
+                raise config.error("zone Offset is malformed, must be a list of x,y,z If you want it blank, use 0,0,0")
+            if len(self.park) < 3:
+                raise config.error("park Offset is malformed, must be a list of x,y,z If you want it blank, use 0,0,0")
+            if len(self.offset) < 3:
+                raise config.error("offset Offset is malformed, must be a list of x,y,z. If you want it blank, use 0,0,0")
+
+        except Exception as e:
+            raise config.error(
+                    "Coordinates of section '%s' is not well formated: %s"
+                    % (config.get_name(), str(e)))
 
         # Tool specific input shaper parameters. Initiated with Klipper standard values where not specified.
         self.shaper_freq_x = config.get('shaper_freq_x', pp_status['shaper_freq_x'])                     
@@ -149,102 +177,137 @@ class Tool:
         self.shaper_damping_ratio_x = config.get('shaper_damping_ratio_x', pp_status['shaper_damping_ratio_x'])                     
         self.shaper_damping_ratio_y = config.get('shaper_damping_ratio_y', pp_status['shaper_damping_ratio_y'])                     
 
-        ##### Standby settings #####
+        ##### Standby settings (if the tool has an extruder) #####
         if self.extruder is not None:
-            if self.physical_parent_id < 0 or self.physical_parent_id == self.name:
-                self.idle_to_standby_time = config.getfloat(
-                    'idle_to_standby_time', tg_status['idle_to_standby_time'], minval = 0.1)
-                self.timer_idle_to_standby = ToolStandbyTempTimer(self.printer, self.name, 1)
+            self.idle_to_standby_time = self.config.getfloat(
+                "idle_to_standby_time", self.pp.idle_to_standby_time)
+            if self.idle_to_standby_time is None:
+                self.idle_to_standby_time = self.toolgroup.idle_to_standby_time
 
-                self.idle_to_powerdown_time = config.getfloat(
-                    'idle_to_powerdown_time', tg_status['idle_to_powerdown_time'], minval = 0.1)
-                self.timer_idle_to_powerdown = ToolStandbyTempTimer(self.printer, self.name, 0)
+            self.idle_to_powerdown_time = self.config.getfloat(
+                "idle_to_powerdown_time", self.pp.idle_to_powerdown_time)
+            if self.idle_to_powerdown_time is None:
+                self.idle_to_powerdown_time = self.toolgroup.idle_to_powerdown_time
+
+            # For all virtual tools that are not also a physical parent, use physical parent's timer.
+            if self.physical_parent_id > self.TOOL_UNLOCKED and self.physical_parent_id != self.name:
+                self.timer_idle_to_standby = self.pp.get_timer_to_standby()
+                self.timer_idle_to_powerdown = self.pp.get_timer_to_powerdown()
             else:
-                self.idle_to_standby_time = pp.idle_to_standby_time
-                self.idle_to_powerdown_time = pp.idle_to_powerdown_time
-                self.timer_idle_to_standby = pp.get_timer_to_standby()
-                self.timer_idle_to_powerdown = pp.get_timer_to_powerdown()
+                # Set up new timers if physical tool.
+                self.timer_idle_to_standby = ToolStandbyTempTimer(self.printer, self.name, ToolStandbyTempTimer.TIMER_TO_STANDBY)
+                self.timer_idle_to_powerdown = ToolStandbyTempTimer(self.printer, self.name, ToolStandbyTempTimer.TIMER_TO_SHUTDOWN)
 
         ##### G-Code ToolChange #####
-        self.pickup_gcode = config.get('pickup_gcode', None)
-        self.dropoff_gcode = config.get('dropoff_gcode', None)
-
-        temp_pickup_gcode = pp.get_pickup_gcode()
-        if temp_pickup_gcode is None:
-            temp_pickup_gcode =  self.toolgroup.get_pickup_gcode()
-        self.pickup_gcode_template = gcode_macro.load_template(config, 'pickup_gcode', temp_pickup_gcode)
-
-        temp_dropoff_gcode = pp.get_dropoff_gcode()
-        if temp_dropoff_gcode is None:
-            temp_dropoff_gcode = self.toolgroup.get_dropoff_gcode()
-        self.dropoff_gcode_template = gcode_macro.load_template(config, 'dropoff_gcode', temp_dropoff_gcode)
+        self.pickup_gcode_template = self._get_gcode_template_with_inheritence('pickup_gcode')
+        self.dropoff_gcode_template = self._get_gcode_template_with_inheritence('dropoff_gcode')
 
         ##### G-Code VirtualToolChange #####
         if self.is_virtual:
-            self.virtual_toolload_gcode = config.get('virtual_toolload_gcode', None)
-            self.virtual_toolunload_gcode = config.get('virtual_toolunload_gcode', None)
+            self.virtual_toolload_gcode_template = self._get_gcode_template_with_inheritence('virtual_toolload_gcode')
+            self.virtual_toolunload_gcode_template = self._get_gcode_template_with_inheritence('virtual_toolunload_gcode')
 
-            temp_virtual_toolload_gcode = pp.get_virtual_toolload_gcode()
-            if temp_virtual_toolload_gcode is None:
-                temp_virtual_toolload_gcode =  self.toolgroup.get_virtual_toolload_gcode()
-            self.virtual_toolload_gcode_template = gcode_macro.load_template(config, 'virtual_toolload_gcode', temp_virtual_toolload_gcode)
+        ##### Parameters for VirtualToolChange #####
+            self.requires_pickup_for_virtual_load = self.config.getboolean(
+                "requires_pickup_for_virtual_load", self.pp.requires_pickup_for_virtual_load)
+            if self.requires_pickup_for_virtual_load is None:
+                self.requires_pickup_for_virtual_load = self.toolgroup.requires_pickup_for_virtual_load
 
-            temp_virtual_toolunload_gcode = pp.get_virtual_toolunload_gcode()
-            if temp_virtual_toolunload_gcode is None:
-                temp_virtual_toolunload_gcode = self.toolgroup.get_virtual_toolunload_gcode()
-            self.virtual_toolunload_gcode_template = gcode_macro.load_template(config, 'virtual_toolunload_gcode', temp_virtual_toolunload_gcode)
+            self.requires_pickup_for_virtual_unload = self.config.getboolean(
+                "requires_pickup_for_virtual_unload", self.pp.requires_pickup_for_virtual_unload)
+            if self.requires_pickup_for_virtual_unload is None:
+                self.requires_pickup_for_virtual_unload = self.toolgroup.requires_pickup_for_virtual_unload
 
+            self.unload_virtual_at_dropoff = self.config.getboolean(
+                "unload_virtual_at_dropoff", self.pp.unload_virtual_at_dropoff)
+            if self.unload_virtual_at_dropoff is None:
+                self.unload_virtual_at_dropoff = self.toolgroup.unload_virtual_at_dropoff
+
+        logging.warn("T%s unload_virtual_at_dropoff: %s" % (str(self.name), str(self.requires_pickup_for_virtual_load)))
+            
         ##### Register Tool select command #####
         self.gcode.register_command("KTCC_T" + str(self.name), self.cmd_SelectTool, desc=self.cmd_SelectTool_help)
 
+    def _get_bool_config_parameter_with_inheritence(self, config_param, default = None):
+        tmp = self.config.getboolean(config_param, self.pp.get_config(config_param))   
+        if tmp is None:
+            tmp = self.toolgroup.get_config(config_param, default)
+        return tmp
 
+    def _get_config_parameter_with_inheritence(self, config_param, default = None):
+        tmp = self.config.get(config_param, self.pp.get_config(config_param))   
+        if tmp is None:
+            tmp = self.toolgroup.get_config(config_param, default)
+        return tmp
+
+    def _get_gcode_template_with_inheritence(self, config_param, optional = False):
+        temp_gcode = self.pp.get_config(config_param)                   # First try to get gcode parameter from eventual physical Parent.
+        if temp_gcode is None:                                          # If didn't get any from physical parent,
+            temp_gcode =  self.toolgroup.get_config(config_param)       # try getting from toolgroup.
+
+        if optional and temp_gcode is None:
+            temp_gcode = ""
+
+        # gcode = self.get_config(config_param, temp_gcode)               # Get from this config and fallback on previous.
+        template = self.gcode_macro.load_template(self.config, config_param, temp_gcode)
+        return template
+
+    def get_config(self, config_param, default = None):
+        if self.config is None: return None
+        return self.config.get(config_param, default)
+        
     cmd_SelectTool_help = "Select Tool"
     def cmd_SelectTool(self, gcmd):
-        self.log.trace("T" + str(self.name) + " Selected.")
+        self.log.trace("KTCC T" + str(self.name) + " Selected.")
+        param = gcmd.get_int('R', None, minval=0, maxval=2)
 
         # Check if the requested tool has been remaped to another one.
         tool_is_remaped = self.toollock.tool_is_remaped(int(self.name))
+
         if tool_is_remaped > -1:
             self.log.always("Tool %d is remaped to Tool %d" % (self.name, tool_is_remaped))
             remaped_tool = self.printer.lookup_object('tool ' + str(tool_is_remaped))
-            remaped_tool.select_tool_actual(gcmd)
+            remaped_tool.select_tool_actual(param)
             return
         else:
-            self.select_tool_actual(gcmd)
+            self.select_tool_actual(param)
+            
 
     # To avoid recursive remaping.
-    def select_tool_actual(self, gcmd):
+    def select_tool_actual(self, param = None):
         current_tool_id = int(self.toollock.get_status()['tool_current']) # int(self.toollock.get_tool_current())
 
         self.log.trace("Current Tool is T" + str(current_tool_id) + ".")
         self.log.trace("This tool is_virtual is " + str(self.is_virtual) + ".")
 
         if current_tool_id == self.name:              # If trying to select the already selected tool:
-            return None                                   # Exit
+            return                                      # Exit
 
         if current_tool_id < self.TOOL_UNLOCKED:
             msg = "TOOL_PICKUP: Unknown tool already mounted Can't park it before selecting new tool."
             self.log.always(msg)
             raise self.printer.command_error(msg)
+        
+        self.log.increase_tool_statistics(self.name, 'toolmounts_started')
+
 
         if self.extruder is not None:               # If the new tool to be selected has an extruder prepare warmup before actual tool change so all unload commands will be done while heating up.
-            self.set_heater(heater_state = 2)
+            self.set_heater(heater_state = self.HEATER_STATE_ACTIVE)
 
         # If optional RESTORE_POSITION_TYPE parameter is passed as 1 or 2 then save current position and restore_position_on_toolchange_type as passed. Otherwise do not change either the restore_position_on_toolchange_type or saved_position. This makes it possible to call SAVE_POSITION or SAVE_CURRENT_POSITION before the actual T command.
-        param = gcmd.get_int('R', None, minval=0, maxval=2)
         if param is not None:
             if param in [ 1, 2 ]:
                 self.toollock.SaveCurrentPosition(param) # Sets restore_position_on_toolchange_type to 1 or 2 and saves current position
             else:
                 self.toollock.SavePosition()  # Sets restore_position_on_toolchange_type to 0
 
-        # Drop any tools already mounted.
-        if current_tool_id > self.TOOL_UNLOCKED:                    # If there is a current tool already selected and it's a dropable.
+        # Drop any tools already mounted if not virtual on same.
+        if current_tool_id > self.TOOL_UNLOCKED:              # If there is a current tool already selected and it's a known tool.
             self.log.track_selected_tool_end(current_tool_id) # Log that the current tool is to be unmounted.
 
             current_tool = self.printer.lookup_object('tool ' + str(current_tool_id))
            
-                                                        # If the next tool is not another virtual tool on the same physical tool.
+            # If the next tool is not another virtual tool on the same physical tool.
             if int(self.physical_parent_id ==  self.TOOL_UNLOCKED or 
                         self.physical_parent_id) !=  int( 
                         current_tool.get_status()["physical_parent_id"]
@@ -252,45 +315,66 @@ class Tool:
                 self.log.info("Will Dropoff():%s" % str(current_tool_id))
                 current_tool.Dropoff()
                 current_tool_id = self.TOOL_UNLOCKED
-            else:
-                self.log.track_unmount_start(current_tool_id)                 # Log the time it takes for tool change.
+            else: # If it's another virtual tool on the same parent physical tool.
                 self.log.info("Dropoff: T" + str(current_tool_id) + "- Virtual - Running UnloadVirtual")
                 current_tool.UnloadVirtual()
-                self.log.track_unmount_end(current_tool_id)                 # Log the time it takes for tool change.
+
 
 
         # Now we asume tool has been dropped if needed be.
-
-        self.log.track_mount_start(self.name)                 # Log the time it takes for tool change.
 
         # Check if this is a virtual tool.
         if not self.is_virtual:
             self.log.trace("cmd_SelectTool: T%s - Not Virtual - Pickup" % str(self.name))
             self.Pickup()
         else:
-            if current_tool_id >= 0:                 # If still has a selected tool: (This tool is a virtual tool with same physical tool as the last)
+            if current_tool_id > self.TOOL_UNLOCKED:                 # If still has a selected tool: (This tool is a virtual tool with same physical tool as the last)
                 current_tool = self.printer.lookup_object('tool ' + str(current_tool_id))
-                self.log.trace("cmd_SelectTool: T" + str(self.name) + "- Virtual - Tool is not Dropped - ")
-                if self.physical_parent_id >= 0 and self.physical_parent_id == current_tool.get_status()["physical_parent_id"]:
+                self.log.trace("cmd_SelectTool: T" + str(self.name) + "- Virtual - Physical Tool is not Dropped - ")
+                if self.physical_parent_id > self.TOOL_UNLOCKED and self.physical_parent_id == current_tool.get_status()["physical_parent_id"]:
                     self.log.trace("cmd_SelectTool: T" + str(self.name) + "- Virtual - Same physical tool - Pickup")
                     self.LoadVirtual()
                 else:
-                    self.log.debug("cmd_SelectTool: T" + str(self.name) + "- Virtual - Not Same physical tool")
-                    self.log.debug("Shouldn't reach this because it is dropped in previous.")
-            else:
+                    msg = "cmd_SelectTool: T" + str(self.name) + "- Virtual - Not Same physical tool"
+                    msg += "Shouldn't reach this because it is dropped in previous."
+                    self.log.debug(msg)
+                    raise Exception(msg)
+            else: # New Physical tool with a virtual tool.
+                pp = self.printer.lookup_object('tool ' + str(self.physical_parent_id))
+                pp_virtual_loaded = pp.get_status()["virtual_loaded"]
                 self.log.trace("cmd_SelectTool: T" + str(self.name) + "- Virtual - Picking upp physical tool")
                 self.Pickup()
+
+                # If the new physical tool already has another virtual tool loaded:
+                if pp_virtual_loaded > self.TOOL_UNLOCKED:
+                    if pp_virtual_loaded != self.name:
+                        self.log.info("cmd_SelectTool: T" + str(pp_virtual_loaded) + "- Virtual - Running UnloadVirtual")
+
+                        uv= self.printer.lookup_object('tool ' + str(pp_virtual_loaded))
+                        if uv.extruder is not None:               # If the new tool to be selected has an extruder prepare warmup before actual tool change so all unload commands will be done while heating up.
+                            curtime = self.printer.get_reactor().monotonic()
+                            # heater = self.printer.lookup_object(self.extruder).get_heater()
+
+                            uv.set_heater(heater_state = self.HEATER_STATE_ACTIVE)
+                            # if int(self.heater_state) == self.HEATER_STATE_ACTIVE and int(self.heater_standby_temp) < int(heater.get_status(curtime)["temperature"]):
+                            self.toollock._Temperature_wait_with_tolerance(curtime, self.extruder, 2)
+                        uv.UnloadVirtual()
+                        self.set_heater(heater_state = self.HEATER_STATE_ACTIVE)
+
+
                 self.log.trace("cmd_SelectTool: T" + str(self.name) + "- Virtual - Picked up physical tool and now Loading virtual tool.")
                 self.LoadVirtual()
 
         self.toollock.SaveCurrentTool(self.name)
-        self.log.track_mount_end(self.name)             # Log number of toolchanges and the time it takes for tool mounting.
         self.log.track_selected_tool_start(self.name)
 
+
     def Pickup(self):
+        self.log.track_mount_start(self.name)                 # Log the time it takes for tool mount.
+
         # Check if homed
         if not self.toollock.PrinterIsHomedForToolchange():
-            raise self.printer.command_error("Tool.Pickup: Printer not homed and Lazy homing option is: " + self.lazy_home_when_parking)
+            raise self.printer.command_error("Tool.Pickup: Printer not homed and Lazy homing option for tool %s is: %s" % (str(self.name), str(self.lazy_home_when_parking)))
             return None
 
         # If has an extruder then activate that extruder.
@@ -305,16 +389,17 @@ class Tool:
             context['myself'] = self.get_status()
             context['toollock'] = self.toollock.get_status()
             self.pickup_gcode_template.run_gcode_from_command(context)
-        except KTCCError as ee:
-            raise KTCCError("Pickup gcode: Script running error: %s" % (str(ee)))
+        except Exception as e:
+            raise Exception("Pickup gcode: Script running error: %s" % (str(e)))
 
         # Restore fan if has a fan.
         if self.fan is not None:
             self.gcode.run_script_from_command(
-                "SET_FAN_SPEED FAN=" + self.fan + " SPEED=" + str(self.toollock.get_status()['saved_fan_speed'])) #  self.toollock.get_saved_fan_speed()) )
+                "SET_FAN_SPEED FAN=" + self.fan + " SPEED=" + str(self.toollock.get_status()['saved_fan_speed']))
 
-        # Set Tool specific input shaper.
+        # Set Tool specific input shaper. -- Deprecated --
         if self.shaper_freq_x != 0 or self.shaper_freq_y != 0:
+            self.log.always("shaper_freq will be deprecated. Use SET_INPUT_SHAPER inside the pickup gcode instead.")
             cmd = ("SET_INPUT_SHAPER" +
                 " SHAPER_FREQ_X=" + str(self.shaper_freq_x) +
                 " SHAPER_FREQ_Y=" + str(self.shaper_freq_y) +
@@ -332,9 +417,10 @@ class Tool:
         else:
             self.log.always("T%d picked up." % (self.name))
 
-    def Dropoff(self):
+        self.log.track_mount_end(self.name)             # Log number of toolchanges and the time it takes for tool mounting.
+
+    def Dropoff(self, force_virtual_unload = False):
         self.log.always("Dropoff: T%s - Running." % str(self.name))
-        self.log.track_unmount_start(self.name)                 # Log the time it takes for tool change.
 
         self.log.track_selected_tool_end(self.name) # Log that the current tool is to be unmounted.
 
@@ -351,17 +437,21 @@ class Tool:
         # Check if this is a virtual tool.
         self.log.trace("Dropoff: T" + str(self.name) + "- is_virtual: " + str(self.is_virtual))
         if self.is_virtual:
-            self.log.info("Dropoff: T" + str(self.name) + "- Virtual - Running UnloadVirtual")
-            self.UnloadVirtual()
+            # Only dropoff if it is required.
+            if self.unload_virtual_at_dropoff or force_virtual_unload:
+                self.log.debug("T%s: unload_virtual_at_dropoff: %s, force_virtual_unload: %s" % (str(self.name), str(self.unload_virtual_at_dropoff), str(force_virtual_unload)))
+                self.log.info("Dropoff: T" + str(self.name) + "- Virtual - Running UnloadVirtual")
+                self.UnloadVirtual()
 
+        self.log.track_unmount_start(self.name)                 # Log the time it takes for tool change.
         # Run the gcode for dropoff.
         try:
             context = self.dropoff_gcode_template.create_template_context()
             context['myself'] = self.get_status()
             context['toollock'] = self.toollock.get_status()
             self.dropoff_gcode_template.run_gcode_from_command(context)
-        except KTCCError as ee:
-            raise KTCCError("Dropoff gcode: Script running error: %s" % (str(ee)))
+        except Exception as e:
+            raise Exception("Dropoff gcode: Script running error: %s" % (str(e)))
 
         self.toollock.SaveCurrentTool(self.TOOL_UNLOCKED)   # Dropoff successfull
         self.log.track_unmount_end(self.name)                 # Log the time it takes for tool change.
@@ -369,6 +459,7 @@ class Tool:
 
     def LoadVirtual(self):
         self.log.info("Loading virtual tool: T%d." % self.name)
+        self.log.track_mount_start(self.name)                 # Log the time it takes for tool mount.
 
         # Run the gcode for Virtual Load.
         try:
@@ -376,15 +467,25 @@ class Tool:
             context['myself'] = self.get_status()
             context['toollock'] = self.toollock.get_status()
             self.virtual_toolload_gcode_template.run_gcode_from_command(context)
-        except KTCCError as ee:
-            raise KTCCError("virtual_toolload_gcode: Script running error: %s" % (str(ee)))
+        except Exception as e:
+            raise Exception("virtual_toolload_gcode: Script running error: %s" % (str(e)))
+
+        pp = self.printer.lookup_object('tool ' + str(self.physical_parent_id))
+        pp.set_virtual_loaded(int(self.name))
 
         # Save current picked up tool and print on screen.
         self.toollock.SaveCurrentTool(self.name)
         self.log.trace("Virtual T%d Loaded" % (int(self.name)))
+        self.log.track_mount_end(self.name)             # Log number of toolchanges and the time it takes for tool mounting.
+
+    def set_virtual_loaded(self, value = -1):
+        self.virtual_loaded = value
+        self.log.trace("Saved VirtualToolLoaded for T%s as: %s" % (str(self.name), str(value)))
+
 
     def UnloadVirtual(self):
         self.log.info("Unloading virtual tool: T%d." % self.name)
+        self.log.track_unmount_start(self.name)                 # Log the time it takes for tool unload.
 
         # Run the gcode for Virtual Unload.
         try:
@@ -392,89 +493,129 @@ class Tool:
             context['myself'] = self.get_status()
             context['toollock'] = self.toollock.get_status()
             self.virtual_toolunload_gcode_template.run_gcode_from_command(context)
-        except KTCCError as ee:
-            raise KTCCError("virtual_toolunload_gcode: Script running error:\n%s" % str(ee))
+        except Exception as e:
+            raise Exception("virtual_toolunload_gcode: Script running error:\n%s" % str(e))
+
+        pp = self.printer.lookup_object('tool ' + str(self.physical_parent_id))
+        pp.set_virtual_loaded(-1)
 
         # Save current picked up tool and print on screen.
         self.toollock.SaveCurrentTool(self.name)
         self.log.trace("Virtual T%d Unloaded" % (int(self.name)))
 
-    # def set_offset(self, **kwargs):
-    #     for i in kwargs:
-    #         if i == "x_pos":
-    #             self.offset[0] = float(kwargs[i])
-    #         elif i == "x_adjust":
-    #             self.offset[0] = float(self.offset[0]) + float(kwargs[i])
-    #         elif i == "y_pos":
-    #             self.offset[1] = float(kwargs[i])
-    #         elif i == "y_adjust":
-    #             self.offset[1] = float(self.offset[1]) + float(kwargs[i])
-    #         elif i == "z_pos":
-    #             self.offset[2] = float(kwargs[i])
-    #         elif i == "z_adjust":
-    #             self.offset[2] = float(self.offset[2]) + float(kwargs[i])
+        self.log.track_unmount_end(self.name)                 # Log the time it takes for tool unload. 
 
-    #     self.log.trace("T%d offset now set to: %f, %f, %f." % (int(self.name), float(self.offset[0]), float(self.offset[1]), float(self.offset[2])))
+    def set_offset(self, **kwargs):
+        for i in kwargs:
+            if i == "x_pos":
+                self.offset[0] = float(kwargs[i])
+            elif i == "x_adjust":
+                self.offset[0] = float(self.offset[0]) + float(kwargs[i])
+            elif i == "y_pos":
+                self.offset[1] = float(kwargs[i])
+            elif i == "y_adjust":
+                self.offset[1] = float(self.offset[1]) + float(kwargs[i])
+            elif i == "z_pos":
+                self.offset[2] = float(kwargs[i])
+            elif i == "z_adjust":
+                self.offset[2] = float(self.offset[2]) + float(kwargs[i])
+
+        self.log.always("T%d offset now set to: %f, %f, %f." % (int(self.name), float(self.offset[0]), float(self.offset[1]), float(self.offset[2])))
+
+    def _set_state(self, heater_state):
+        self.heater_state = heater_state
+
 
     def set_heater(self, **kwargs):
         if self.extruder is None:
             self.log.debug("set_heater: T%d has no extruder! Nothing to do." % self.name )
             return None
 
+        # self.log.info("T%d heater is at begingin %s." % (self.name, self.heater_state ))
+
         heater = self.printer.lookup_object(self.extruder).get_heater()
         curtime = self.printer.get_reactor().monotonic()
+        changing_timer = False
+        
+        # self is always pointing to virtual tool but its timers and extruder are always pointing to the physical tool. When changing multiple virtual tools heaters the statistics can remain open when changing by timers of the parent if another one got in between.
+        # Therefore it's important for all heater statistics to only point to physical parent.
 
+        if self.is_virtual == True:
+            tool_for_tracking_heater = self.physical_parent_id
+        else:
+            tool_for_tracking_heater = self.name
+
+        # First set state if changed, so we set correct temps.
+        if "heater_state" in kwargs:
+            chng_state = kwargs["heater_state"]
         for i in kwargs:
             if i == "heater_active_temp":
                 self.heater_active_temp = kwargs[i]
-                if int(self.heater_state) == 2:
+                if int(self.heater_state) == self.HEATER_STATE_ACTIVE:
                     heater.set_temp(self.heater_active_temp)
             elif i == "heater_standby_temp":
                 self.heater_standby_temp = kwargs[i]
+                if int(self.heater_state) == self.HEATER_STATE_STANDBY:
+                    heater.set_temp(self.heater_standby_temp)
             elif i == "idle_to_standby_time":
                 self.idle_to_standby_time = kwargs[i]
+                changing_timer = True
             elif i == "idle_to_powerdown_time":
                 self.idle_to_powerdown_time = kwargs[i]
+                changing_timer = True
 
-        # Change Active mode:
+        # If already in standby and timers are counting down, i.e. have not triggered since set in standby, then reset the ones counting down.
+        if int(self.heater_state) == self.HEATER_STATE_STANDBY and changing_timer:
+            if self.timer_idle_to_powerdown.get_status()["counting_down"] == True:
+                self.timer_idle_to_powerdown.set_timer(self.idle_to_powerdown_time, self.name)
+                if self.idle_to_powerdown_time > 2:
+                    self.log.info("T%d heater will shut down in %s seconds." % (self.name, self.log._seconds_to_human_string(self.idle_to_powerdown_time) ))
+            if self.timer_idle_to_standby.get_status()["counting_down"] == True:
+                self.timer_idle_to_standby.set_timer(self.idle_to_standby_time, self.name)
+                if self.idle_to_standby_time > 2:
+                    self.log.info("T%d heater will go in standby in %s seconds." % (self.name, self.log._seconds_to_human_string(self.idle_to_standby_time) ))
+
+
+        # Change Active mode, Continuing with part two of temp changing.:
         if "heater_state" in kwargs:
-            chng_state = kwargs["heater_state"]
             if self.heater_state == chng_state:                                                         # If we don't actually change the state don't do anything.
-                self.log.trace("set_heater: T%d heater state not changed." % self.name )
+                if chng_state == self.HEATER_STATE_ACTIVE:
+                    self.log.trace("set_heater: T%d heater state not changed. Setting active temp." % self.name )
+                    heater.set_temp(self.heater_active_temp)
+                elif chng_state == self.HEATER_STATE_STANDBY:
+                    self.log.trace("set_heater: T%d heater state not changed. Setting standby temp." % self.name )
+                    heater.set_temp(self.heater_standby_temp)
+                else:
+                    self.log.trace("set_heater: T%d heater state not changed." % self.name )
                 return None
-            if chng_state == 0:                                                                         # If Change to Shutdown
-                self.timer_idle_to_standby.set_timer(0)
-                self.timer_idle_to_powerdown.set_timer(0.1)
-                self.log.track_standby_heater_end(self.name)                                                # Set the standby as finishes in statistics.
-                self.log.track_active_heater_end(self.name)                                                # Set the active as finishes in statistics.
-            elif chng_state == 2:                                                                       # Else If Active
-                self.timer_idle_to_standby.set_timer(0)
-                self.timer_idle_to_powerdown.set_timer(0)
+            if chng_state == self.HEATER_STATE_OFF:                                                                         # If Change to Shutdown
+                self.log.trace("set_heater: T%d heater state now OFF." % self.name )
+                self.timer_idle_to_standby.set_timer(0, self.name)
+                self.timer_idle_to_powerdown.set_timer(0.1, self.name)
+                # self.log.track_standby_heater_end(self.name)                                                # Set the standby as finishes in statistics.
+                # self.log.track_active_heater_end(self.name)                                                # Set the active as finishes in statistics.
+            elif chng_state == self.HEATER_STATE_ACTIVE:                                                                       # Else If Active
+                self.log.trace("set_heater: T%d heater state now ACTIVE." % self.name )
+                self.timer_idle_to_standby.set_timer(0, self.name)
+                self.timer_idle_to_powerdown.set_timer(0, self.name)
                 heater.set_temp(self.heater_active_temp)
-                self.log.track_standby_heater_end(self.name)                                                # Set the standby as finishes in statistics.
-                self.log.track_active_heater_start(self.name)                                               # Set the active as started in statistics.
-            elif chng_state == 1:                                                                       # Else If Standby
-                if int(self.heater_state) == 2 and int(self.heater_standby_temp) < int(heater.get_status(curtime)["temperature"]):
-                    self.timer_idle_to_standby.set_timer(self.idle_to_standby_time)
-                    self.timer_idle_to_powerdown.set_timer(self.idle_to_powerdown_time)
+                self.log.track_standby_heater_end(tool_for_tracking_heater)                                                # Set the standby as finishes in statistics.
+                self.log.track_active_heater_start(tool_for_tracking_heater)                                               # Set the active as started in statistics.
+            elif chng_state == self.HEATER_STATE_STANDBY:                                                                       # Else If Standby
+                self.log.trace("set_heater: T%d heater state now STANDBY." % self.name )
+                if int(self.heater_state) == self.HEATER_STATE_ACTIVE and int(self.heater_standby_temp) < int(heater.get_status(curtime)["temperature"]):
+                    self.timer_idle_to_standby.set_timer(self.idle_to_standby_time, self.name)
+                    self.timer_idle_to_powerdown.set_timer(self.idle_to_powerdown_time, self.name)
+                    if self.idle_to_standby_time > 2:
+                        self.log.always("T%d heater will go in standby in %s seconds." % (self.name, self.log._seconds_to_human_string(self.idle_to_standby_time) ))
                 else:                                                                                   # Else (Standby temperature is lower than the current temperature)
                     self.log.trace("set_heater: T%d standbytemp:%d;heater_state:%d; current_temp:%d." % (self.name, int(self.heater_state), int(self.heater_standby_temp), int(heater.get_status(curtime)["temperature"])))
-                    self.timer_idle_to_standby.set_timer(0.1)
-                    self.timer_idle_to_powerdown.set_timer(self.idle_to_powerdown_time)
+                    self.timer_idle_to_standby.set_timer(0.1, self.name)
+                    self.timer_idle_to_powerdown.set_timer(self.idle_to_powerdown_time, self.name)
+                if self.idle_to_powerdown_time > 2:
+                    self.log.always("T%d heater will shut down in %s seconds." % (self.name, self.log._seconds_to_human_string(self.idle_to_powerdown_time)))
             self.heater_state = chng_state
-        # self.log.trace("Heater mode changed: T%d heater_state now set to:%d. Current_temp:%d, Standbytemp:%d, ActiveTemp:%d." % (int(self.name), int(self.heater_state), int(heater.get_status(curtime)["temperature"]), int(self.heater_standby_temp), int(heater.set_temp(self.heater_active_temp))))
 
-    def get_pickup_gcode(self):
-        return self.pickup_gcode
-
-    def get_dropoff_gcode(self):
-        return self.dropoff_gcode
-
-    def get_virtual_toolload_gcode(self):
-        return self.virtual_toolload_gcode
-
-    def get_virtual_toolunload_gcode(self):
-        return self.virtual_toolunload_gcode
 
     def get_timer_to_standby(self):
         return self.timer_idle_to_standby
@@ -498,21 +639,30 @@ class Tool:
             "heater_active_temp": self.heater_active_temp,
             "heater_standby_temp": self.heater_standby_temp,
             "idle_to_standby_time": self.idle_to_standby_time,
-            "idle_to_powerdown_time": self.idle_to_powerdown_time,
+            "idle_to_powerdown_next_wake": self.idle_to_powerdown_time,
             "shaper_freq_x": self.shaper_freq_x,
             "shaper_freq_y": self.shaper_freq_y,
             "shaper_type_x": self.shaper_type_x,
             "shaper_type_y": self.shaper_type_y,
             "shaper_damping_ratio_x": self.shaper_damping_ratio_x,
-            "shaper_damping_ratio_y": self.shaper_damping_ratio_y
+            "shaper_damping_ratio_y": self.shaper_damping_ratio_y,
+            "virtual_loaded": self.virtual_loaded,
+            "requires_pickup_for_virtual_load": self.requires_pickup_for_virtual_load,
+            "requires_pickup_for_virtual_unload": self.requires_pickup_for_virtual_unload,
+            "unload_virtual_at_dropoff": self.unload_virtual_at_dropoff
         }
         return status
 
     # Based on DelayedGcode.
 class ToolStandbyTempTimer:
+    TIMER_TO_SHUTDOWN = 0
+    TIMER_TO_STANDBY = 1
+
     def __init__(self, printer, tool_id, temp_type):
         self.printer = printer
         self.tool_id = tool_id
+        self.last_virtual_tool_using_physical_timer = None
+
         self.duration = 0.
         self.temp_type = temp_type      # 0= Time to shutdown, 1= Time to standby.
 
@@ -524,6 +674,9 @@ class ToolStandbyTempTimer:
         self.toollock = self.printer.lookup_object('toollock')
         self.log = self.printer.lookup_object('ktcclog')
 
+        self.counting_down = False
+        self.nextwake = self.reactor.NEVER
+
 
     def _handle_ready(self):
         self.timer_handler = self.reactor.register_timer(
@@ -531,48 +684,93 @@ class ToolStandbyTempTimer:
 
     def _standby_tool_temp_timer_event(self, eventtime):
         self.inside_timer = True
-        self.log.trace("_standby_tool_temp_timer_event: Running for T%s. temp_type:%s." % (str(self.tool_id), "Time to shutdown" if self.temp_type == 0 else "Time to standby"))
+        self.counting_down = False
         try:
-            tool = self.printer.lookup_object("tool " + str(self.tool_id))
+            if self.last_virtual_tool_using_physical_timer is None:
+                raise Exception("last_virtual_tool_using_physical_timer is < None")
+
+            tool = self.printer.lookup_object("tool " + str(self.last_virtual_tool_using_physical_timer))
+            if tool.is_virtual == True:
+                tool_for_tracking_heater = tool.physical_parent_id
+            else:
+                tool_for_tracking_heater = tool.name
+
+
+
+            self.log.trace(
+                "_standby_tool_temp_timer_event: Running for T%s. temp_type:%s. %s" % 
+                (str(self.tool_id), 
+                 "Time to shutdown" if self.temp_type == 0 else "Time to standby", 
+                 ("For virtual tool T%s" % str(self.last_virtual_tool_using_physical_timer) ) 
+                 if  self.last_virtual_tool_using_physical_timer != self.tool_id else ""))
+
             temperature = 0
-            if self.temp_type == 1:
-                temperature = tool.get_status()["heater_standby_temp"]
+            heater = self.printer.lookup_object(tool.extruder).get_heater()
+            if self.temp_type == self.TIMER_TO_STANDBY:
                 self.log.track_standby_heater_start(self.tool_id)                                                # Set the standby as started in statistics.
+                temperature = tool.get_status()["heater_standby_temp"]
+                heater.set_temp(temperature)
+                # self.log.trace("_standby_tool_temp_timer_event: Running heater.set_temp(%s)" % str(temperature))
             else:
                 self.log.track_standby_heater_end(self.tool_id)                                                # Set the standby as finishes in statistics.
-                self.log.track_active_heater_end(self.tool_id)                                                 # Set the active as finishes in statistics.
-            heater = self.printer.lookup_object(tool.extruder).get_heater()
-            heater.set_temp(temperature)
-            self.log.trace("_standby_tool_temp_timer_event: Running heater.set_temp(%s)" % str(temperature))
+
+                tool.get_timer_to_standby().set_timer(0, self.last_virtual_tool_using_physical_timer)        # Stop Standby timer.
+                #tool.get_timer_to_powerdown().set_timer(0, self.last_virtual_tool_using_physical_timer)        # Stop Poweroff timer. (Already off)
+                tool._set_state(Tool.HEATER_STATE_OFF)        # Set off state.
+                heater.set_temp(0)        # Set temperature to 0.
+
+
+                # tool.set_heater(Tool.HEATER_STATE_OFF)
             self.log.track_active_heater_end(self.tool_id)                                               # Set the active as finishes in statistics.
 
-        except KTCCError as ee:
-            raise KTCCError("Failed to set Standby temp for tool T%s: %s" % (str(self.tool_id), str(ee)))
+        except Exception as e:
+            raise Exception("Failed to set Standby temp for tool T%s: %s. %s" % (str(self.tool_id), 
+                                                                                 ("for virtual T%s" % str(self.last_virtual_tool_using_physical_timer)),
+                                                                                 str(e)))  # if actual_tool_calling != self.tool_id else ""
 
-        nextwake = self.reactor.NEVER
+        self.nextwake = self.reactor.NEVER
         if self.repeat:
-            nextwake = eventtime + self.duration
+            self.nextwake = eventtime + self.duration
+            self.counting_down = True
         self.inside_timer = self.repeat = False
-        return nextwake
+        return self.nextwake
 
-    def set_timer(self, duration):
-        self.log.trace(str(self.timer_handler) + ".set_timer: T" + str(self.tool_id) + "; temp_type:" + str(self.temp_type) + "; duration:" + str(duration) + ".")
+    def set_timer(self, duration, actual_tool_calling):
+        actual_tool_calling = actual_tool_calling
+        self.log.trace(str(self.timer_handler) + ".set_timer: T%s %s, temp_type:%s, duration:%s." % (
+            str(self.tool_id), 
+            ("for virtual T%s" % str(actual_tool_calling)) if actual_tool_calling != self.tool_id else "",
+            ("Standby" if self.temp_type == 1 else "OFF"), 
+            str(duration)))
         self.duration = float(duration)
+        self.last_virtual_tool_using_physical_timer = actual_tool_calling
         if self.inside_timer:
             self.repeat = (self.duration != 0.)
         else:
             waketime = self.reactor.NEVER
             if self.duration:
                 waketime = self.reactor.monotonic() + self.duration
+                self.nextwake = waketime
             self.reactor.update_timer(self.timer_handler, waketime)
+            self.counting_down = True
 
     def get_status(self, eventtime= None):
         status = {
-            "tool": self.tool,
+            # "tool": self.tool,
             "temp_type": self.temp_type,
-            "duration": self.duration
+            "duration": self.duration,
+            "counting_down": self.counting_down,
+            "next_wake": self._time_left()
+
         }
         return status
+
+    def _time_left(self):
+        if self.nextwake == self.reactor.NEVER:
+            return "never"
+        else:
+            return str( self.nextwake - self.reactor.monotonic() )
+
 
     # Todo: 
     # Inspired by https://github.com/jschuh/klipper-macros/blob/main/layers.cfg

--- a/toolgroup.py
+++ b/toolgroup.py
@@ -19,7 +19,8 @@ class ToolGroup:
     def __init__(self, config):
         self.printer = config.get_printer()
         self.name = config.get_name().split(' ')[1]
-        gcode_macro = self.printer.load_object(config, 'gcode_macro')
+        self.config = config
+        # gcode_macro = self.printer.load_object(config, 'gcode_macro')
 
         try:
             _, name = config.get_name().split(' ', 1)
@@ -43,18 +44,14 @@ class ToolGroup:
         self.idle_to_standby_time = config.getfloat( 'idle_to_standby_time', 30, minval = 0.1)
         self.idle_to_powerdown_time = config.getfloat( 'idle_to_powerdown_time', 600, minval = 0.1)
 
-    def get_pickup_gcode(self):
-        return self.pickup_gcode
+        self.requires_pickup_for_virtual_load = self.config.getboolean("requires_pickup_for_virtual_load", True)
+        self.requires_pickup_for_virtual_unload = self.config.getboolean("requires_pickup_for_virtual_unload", True)
+        self.unload_virtual_at_dropoff = self.config.getboolean("unload_virtual_at_dropoff", True)
 
-    def get_dropoff_gcode(self):
-        return self.dropoff_gcode
 
-    def get_virtual_toolload_gcode(self):
-        return self.virtual_toolload_gcode
-
-    def get_virtual_toolunload_gcode(self):
-        return self.virtual_toolunload_gcode
-
+    def get_config(self, config_param, default = None):
+        return self.config.get(config_param, default)
+        
     def get_status(self, eventtime= None):
         status = {
             "is_virtual": self.is_virtual,
@@ -62,7 +59,10 @@ class ToolGroup:
             "lazy_home_when_parking": self.lazy_home_when_parking,
             "meltzonelength": self.meltzonelength,
             "idle_to_standby_time": self.idle_to_standby_time,
-            "idle_to_powerdown_time": self.idle_to_powerdown_time
+            "idle_to_powerdown_time": self.idle_to_powerdown_time,
+            "requires_pickup_for_virtual_load": self.requires_pickup_for_virtual_load,
+            "requires_pickup_for_virtual_unload": self.requires_pickup_for_virtual_unload,
+            "unload_virtual_at_dropoff": self.unload_virtual_at_dropoff
         }
         return status
 


### PR DESCRIPTION
- New command KTCC_ENDSTOP_QUERY: Wait for a ENDSTOP= untill it is TRIGGERED=0/[1] or ATEMPTS=#. This is usefull for Jubilee style printers being able to pause and not execute any other code.
- New command KTCC_SET_ALL_TOOL_HEATERS_OFF: Turns off all heaters and saves changes made to be resumed by KTCC_RESUME_ALL_TOOL_HEATERS.
- New command KTCC_RESUME_ALL_TOOL_HEATERS: Resumes all heaters previously turned off by KTCC_SET_ALL_TOOL_HEATERS_OFF.
- Fix statistics bug.
- Fix bug if trying to save statistics and state while homing. For example if Z-probe is mounted on a tool and it is mounted then it will want to save that but Klipper is bussy so it will crash unless checking if homing and delaying saving.
- Added confirmation for resetting statistics..